### PR TITLE
Add information about CSRF Protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 ## Ignore project files created by Eclipse
 .settings/
 .project

--- a/README.md
+++ b/README.md
@@ -1,15 +1,8 @@
 # DSpace 7 REST Contract
 
-This repository documents the new REST API Contract for DSpace 7. The code to implement this contract is on the DSpace [`main` branch](https://github.com/DSpace/DSpace/tree/main/dspace-server-webapp)
-
-***
-:warning: **As the DSpace 7 REST API is under active development, this REST Contract is expected to change rapidly.** REST Contract contributors will be rapidly adding ideas (via Pull Requests) to this repository in order to enable the detailed discussions necessary to finalize the REST Contract. Once the REST Contract stabilizes, we will remove this warning and more actively publicize it.
-
-**If you would like to get involved in our DSpace 7 development effort, we welcome new contributors.**
-  * DSpace 7 Meetings can be found on the [DSpace 7 Working Group](https://wiki.lyrasis.org/display/DSPACE/DSpace+7+Working+Group) wiki page.
-  * DSpace 7 REST API development work (corresponding to this contract) is occurring on the DSpace [`main` branch](https://github.com/DSpace/DSpace/tree/main/dspace-server-webapp)
-  * DSpace 7 Angular UI work is occurring at https://github.com/DSpace/dspace-angular
-***
+This repository documents new DSpace REST API Contract beginning with version 7.0.
+* The code that implements this contract is on the  [`main` branch](https://github.com/DSpace/DSpace/tree/main/dspace-server-webapp) of the DSpace backend.
+* One example client which utilizes this contract is the [DSpace User Interface](https://github.com/DSpace/dspace-angular/), built in [Angular.io](https://angular.io/).
 
 ## Table of Contents
 * [REST Endpoints](#rest-endpoints)
@@ -42,6 +35,7 @@ At the ROOT of the API a HAL document lists all the primary endpoints allowing f
 * [Endpoints](endpoints.md) - Documentation for all available endpoints
 * [Search Options and Relationships (on Endpoints)](search-rels.md) - How to use `/search` sub-paths on many endpoints
 * [Projections (on Endpoints)](projections.md) - How to use projections to return a subset or custom view of content
+* [CSRF Protection (on Endpoints)](csrf-tokens.md) - When using modifying verbs (POST, PUT, PATCH, DELETE), you *must* pass a CSRF token in the request.
 
 ## Use of HTTP Verbs and Response Codes
 
@@ -130,7 +124,7 @@ Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the associ
 ### Error Codes
 * `400 Bad Request` - if multiple URIs were given for a to-one-association
 * `401 Unauthorized` (Unauthenticated) - if the request requires a logged-in user
-* `403 Forbidden` - if the requester doesn't have enough privilege to execute the request
+* `403 Forbidden` - if the requester doesn't have enough privilege to execute the request, or the request requires [CSRF protection](csrf-tokens.md) and the CSRF token was missing or invalid.
 * `404 Not Found` - if the requested entity or collection doesn't exist
 * `405 Method Not Allowed` - if the method is not implemented, or a DELETE method is called on a non-optional association
 * `422 Unprocessable Entity` - if the request is well-formed, but is invalid based on the given data. For example, if you attempt to create a resource under a non-existent parent resource, or attempt to update a read-only (non-editable) field.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository documents the new REST API Contract for DSpace 7. The code to im
 :warning: **As the DSpace 7 REST API is under active development, this REST Contract is expected to change rapidly.** REST Contract contributors will be rapidly adding ideas (via Pull Requests) to this repository in order to enable the detailed discussions necessary to finalize the REST Contract. Once the REST Contract stabilizes, we will remove this warning and more actively publicize it.
 
 **If you would like to get involved in our DSpace 7 development effort, we welcome new contributors.**
-  * DSpace 7 Meetings and subteams can be found on the [DSpace 7 Working Group](https://wiki.lyrasis.org/display/DSPACE/DSpace+7+Working+Group) wiki page.
+  * DSpace 7 Meetings can be found on the [DSpace 7 Working Group](https://wiki.lyrasis.org/display/DSPACE/DSpace+7+Working+Group) wiki page.
   * DSpace 7 REST API development work (corresponding to this contract) is occurring on the DSpace [`main` branch](https://github.com/DSpace/DSpace/tree/main/dspace-server-webapp)
   * DSpace 7 Angular UI work is occurring at https://github.com/DSpace/dspace-angular
 ***
@@ -132,7 +132,7 @@ Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the associ
 * `401 Unauthorized` (Unauthenticated) - if the request requires a logged-in user
 * `403 Forbidden` - if the requester doesn't have enough privilege to execute the request
 * `404 Not Found` - if the requested entity or collection doesn't exist
-* `405 Method Not Allowed` - if the method is not implemented or a DELETE method is called on a non-optional association
+* `405 Method Not Allowed` - if the method is not implemented, or a DELETE method is called on a non-optional association
 * `422 Unprocessable Entity` - if the request is well-formed, but is invalid based on the given data. For example, if you attempt to create a resource under a non-existent parent resource, or attempt to update a read-only (non-editable) field.
 
 ## Pagination
@@ -159,7 +159,7 @@ An example
     "number": 0
 }
 ```
-and, when applicable, the following links
+When applicable, the following links may also appear:
 - `self` - a parameterized link to the requested collection page
 - `next` - the link to the next page of resources in the collection, if any, keeping the same option for size and sorting
 - `previous` - the link to the previous page of resources in the collection, if any, keeping the same option for size and sorting
@@ -185,10 +185,10 @@ An example
 ```
 
 ### Out of Bound Pages
-If the request parameters lead to a page outside the result set, then an empty page should be returned with the links needed to go to the first and last page of the result set (if the results set is not empty) and the total number of resources in the collection.
+If the request parameters lead to a page outside the result set, then an empty page should be returned with the links needed to go to the first and last page of the result set (if the results set is not empty), and the total number of resources in the collection.
 
 ### Pagination Error Codes
-`400 Bad Request` - If an unknown sort criteria is requested or a not valid ordering keyword is specified
+`400 Bad Request` - If an unknown sort criteria is requested, or a not valid ordering keyword is specified
 
 ## REST Design Principles
 In the creation of the REST API, we've tried to follow a few specific design principles listed below
@@ -237,7 +237,7 @@ While most i18n (internationalization) settings exist in the UI layer, there are
 For such features the `Accept-Language` header may be used by the REST client to force the use of a specific locale, if supported by the DSpace instance and endpoint in the response. (Please note that not all the DSpace instances support multiple locales. This can be discovered by querying the configuration endpoint for the `webui.supported.locales` key.)
 
 If the support for multiple locales is enabled in the DSpace instance, a request with an `Accept-Language` header is expected to be processed as follows:
-* If none of the requested locales is supported, the server will ignore the header. This provides more user friendly behavior when browsing the REST API via a browser (see https://tools.ietf.org/html/rfc7231#section-5.3.5)
+* If none of the requested locales is supported, the server will ignore the header. This provides more user-friendly behavior when browsing the REST API via a browser (see https://tools.ietf.org/html/rfc7231#section-5.3.5)
 * If at least one acceptable locale is requested, the server will use the one with the higher priority in the `Accept-Language` header to process the request
 * If the requested endpoint is configured to respond differently based on the selected locale, then the `Content-Language` response header will detail which locale was used to generate the response.
 * If the requested endpoint responds the same no matter which locale is requested, then the `Content-Language` response will return the list of all supported locales.
@@ -261,17 +261,15 @@ The ETag header (<http://tools.ietf.org/html/rfc7232#section-2.3>) provides a wa
 
 The ETag value can be used with in GET request with the *If-None-Match* conditional header. If the header MATCHES the ETag, the API will conclude nothing has changed, and instead of sending a copy of the resource, an HTTP 304 Not Modified status code is returned.
 
-The ETag value can be also used with DELETE, POST, PUT and PATCH with the *If-Match* conditional header to avoid to perform action on changed resources (concurrency issues, optimistic lock approach).
+The ETag value can be also used with DELETE, POST, PUT and PATCH with the *If-Match* conditional header to avoid performing an action on changed resources (concurrency issues, optimistic lock approach).
 
 Finally, when possible the If-Modified-Since header in GET request should be respected. If the resource has been not modified since the value of the Header the API should return an
-HTTP 304 Not Modified status code. Resources that support the *If-Modified-Since* header *MUST* return the Last-Modified Header in the GET response, such header *MUST BE NOT* returned by resources not able to manage the If-Modified-Since header.
+HTTP 304 Not Modified status code. Resources that support the *If-Modified-Since* header *MUST* return the Last-Modified Header in the GET response. That header *MUST BE NOT* returned by resources not able to manage the If-Modified-Since header.
 
 ## API Versioning
-... here we will describe our strategy to provide access overtime to a specific version of the REST API...
-### Deprecated endpoints & methods
-... how we want to let know the client about deprecated endpoints & methods?
-### Experimental endpoints & methods
-... do we want/need to introduce endpoints keeping the right to change behavior and other aspects without face with the self-imposed guarantee about backward compatibilty and versioning?
+
+At this time, DSpace REST API is versioned alongside DSpace software (e.g. DSpace v7.x comes with REST API v7).
+Please check the Release Notes for information around any deprecations / breaking changes to the API between major versions of DSpace.
 
 ## Community Resources
 * [REST Code Branch](https://github.com/DSpace/DSpace/tree/main/dspace-server-webapp)

--- a/authentication.md
+++ b/authentication.md
@@ -7,9 +7,9 @@ Information about the underline implementation are [available on the wiki](https
 ## Login
 **POST /api/authn/login**
 
-This endpoint only accept the POST method. Parameters and body structure depend on the authentication method to use.
+This endpoint only accepts the `POST` method. Parameters and body structure depend on the authentication method to use.
 
-A WWW-Authenticate header is returned listing the different authentication method supported by the system.
+A `WWW-Authenticate` header is returned listing the different authentication method supported by the system.
 Below an example listing the password and shibboleth authentication:  
 `WWW-Authenticate: shibboleth realm="DSpace REST API", location="https://dspace7.4science.cloud/Shibboleth.sso/Login?target=https%3A%2F%2Fdspace7.4science.cloud", password realm="DSpace REST API"`
 
@@ -18,7 +18,7 @@ Return codes
 - 401 Unauthorized. If the login fails. The response Header WWW-Authentication must be inspected to discover the supported authentication method
 
 ### Username Password based authentication
-Parameters must be sent in the body of a x-www-form-urlencoded request, i.e
+Parameters must be sent in the body of a `x-www-form-urlencoded` request, i.e
 
 ```
 curl -v -X POST https://{dspace-server.url}/server/api/authn/login --data "user=dspacedemo%2Badmin%40gmail.com&password=dspace"
@@ -61,24 +61,26 @@ sg | Contains the id's of the special groups to which a user belongs
 exp | Contains the expiration date when a token will expire
 
 ## Logout
-**/api/authn/logout**
+**POST /api/authn/logout**
 
-To logout and invalidate the JWT token, send the token in the Authorization header with the bearer scheme to the endpoint either with a GET or POST request
+This endpoint only accepts the `POST` method.
+
+To logout and invalidate the JWT token, send the token in the `Authorization` header with the bearer scheme.
 
 ```
-curl -v "http://{dspace-server.url}/api/authn/logout" -H "Authorization: Bearer eyJhbG...COdbo"
+curl -v -X POST "http://{dspace-server.url}/api/authn/logout" -H "Authorization: Bearer eyJhbG...COdbo"
 ```
 
-This invalidate the token on the server side with the result to log the user out on every device or browser. It can also be called with params **action** and **return**, required by the Shibboleth Single Logout (front channel), with the same behaviour.
+This invalidates the token on the server side with the result to log the user out on every device or browser. It can also be called with params **action** and **return**, required by the Shibboleth Single Logout (front channel), with the same behaviour.
 
 Return code
-- 204 No content
-- 302 Found. If a successful logout occurs and a logout page URL is configured
+- 204 No content.
+- 302 Found. If a successful logout occurs, and a logout page URL is configured
 
-Invalid or missing token are not reported, i.e. the endpoint will always return 204 also if no token is supplied or the token is invalid
+Invalid or missing tokens are not reported, i.e. the endpoint will always return 204 also if no token is supplied, or the token is invalid
 
 ## Status
-** /api/authn/status **
+**/api/authn/status**
 
 The authentication status can be checked by sending your received token to the status endpoint in the Authorization header in a GET request:
 

--- a/csrf-tokens.md
+++ b/csrf-tokens.md
@@ -5,6 +5,7 @@ All modifying requests (`POST`, `PUT`, `PATCH`, `DELETE`, etc) **require** that 
 in the `X-XSRF-TOKEN` header, otherwise a `403 Forbidden` error will occur. 
 
 The CSRF token is sent to the client in a prior request (often a `GET`) and may be changed during your session at any time.
+See [How does CSRF protection work in DSpace?](#how-does-csrf-protection-work-in-dspace) below for more details.
 
 ## What is CSRF and why is this necessary?
 

--- a/csrf-tokens.md
+++ b/csrf-tokens.md
@@ -1,0 +1,36 @@
+# CSRF Protection
+[REST Overview Documentation](README.md)
+
+All modifying requests (`POST`, `PUT`, `PATCH`, `DELETE`, etc) **require** that the client send a valid CSRF token
+in the `X-XSRF-TOKEN` header, otherwise a `403 Forbidden` error will occur. 
+
+The CSRF token is sent to the client in a prior request (often a `GET`) and may be changed during your session at any time.
+
+## What is CSRF and why is this necessary?
+
+CSRF (or sometimes XSRF) refers to [Cross Site Request Forgery](https://owasp.org/www-community/attacks/csrf) attacks, where
+an end user may be tricked into executing unwanted actions on a web application in which they are currently authenticated.
+
+DSpace follows [OWASP guidelines to CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
+by enabling [Spring Security's CSRF Protection](https://docs.spring.io/spring-security/site/docs/current/reference/html5/#csrf)
+
+DSpace uses a customized version of [Spring Security's CSRF Protection](https://docs.spring.io/spring-security/site/docs/current/reference/html5/#csrf)
+which also works cross-domain (allowing clients to be on entirely separate domains from the REST API).
+Please keep in mind that clients on other domains *must* still be trusted by the REST API by configuring the [CORS (Cross-Origin Resource Sharing)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+`Access-Control-Allow-Origin` header.
+
+## How does CSRF protection work in DSpace?
+
+1. The DSpace REST API generates a CSRF Token, storing it in a `HttpOnly` Cookie named `DSPACE-XSRF-COOKIE`, and sending
+it back to the client in a header named `DSPACE-XSRF-TOKEN`.
+   * This token is often generated on your first request to the REST API, but may also
+    be updated at any time.
+2. The client **MUST** store/keep a copy of this CSRF token (usually by watching for the `DSPACE-XSRF-TOKEN` header in every response),
+and update that stored copy whenever a new token is sent.
+3. Whenever the client wishes to make a modifying request (`POST`, `PUT`, `PATCH`, `DELETE`, etc), 
+the current CSRF token **MUST** be sent back in the `X-XSRF-TOKEN` header of the request.
+   * Keep in mind that [authentication](authentication.md) (via `/api/authn/login`) requires `POST` and therefore also requires a valid CSRF token.
+   * NOTE: non-modifying requests (`GET`, `HEAD`, `OPTIONS`, etc) do not require the token.
+4. During a modifying request, the REST API will compare the value of the CSRF token in the request's
+`X-XSRF-TOKEN` header to the value in the `DSPACE-XSRF-COOKIE` Cookie. If the values match, the request proceeds.
+If the values do not match, a `403 Forbidden` error is returned.


### PR DESCRIPTION
This PR updates our REST Contract based on https://github.com/DSpace/DSpace/pull/3103

* Adds information about CSRF Protection to README & a new `csrf-tokens.md` page for more details
* Updates docs on Logout to note that it now requires `POST`
* Other minor cleanup to README (including removing the warning at the top) & .gitignore