### PR TITLE
Support a short lived token using GET to deal with CSRF in Angular

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -171,6 +171,15 @@ Return codes
 - 200 Ok. 
 - 401 Unauthorized. If no user is logged in
 
+## Request short lived token using GET
+
+**GET /api/authn/shortlivedtokens**
+
+The short lived token can also be retrieved using GET, if it originates from a trusted IP.
+
+This can be used by Angular to retrieve a short lived token when a POST is not possible.
+It works identical to the [POST endpoint](#request-short-lived-token)
+
 ### Using short lived token
 
 The request parameter below can be used for nearly every REST endpoint to perform it with authentication but without needing the authentication header:


### PR DESCRIPTION
This is related to https://github.com/DSpace/dspace-angular/pull/1004#issuecomment-811875846

It adds the GET endpoint as an alternative, which is only available from the trusted IP