### PR TITLE
BUGFIX: Reflect changes in PR #3054

### DIFF
--- a/claimedtasks.md
+++ b/claimedtasks.md
@@ -1,4 +1,4 @@
-# Claimed Taks Endpoints
+# Claimed Tasks Endpoints
 [Back to the list of all defined endpoints](endpoints.md)
 
 ## Main Endpoint

--- a/pooltasks.md
+++ b/pooltasks.md
@@ -1,4 +1,4 @@
-# Pool Taks Endpoints
+# Pool Tasks Endpoints
 [Back to the list of all defined endpoints](endpoints.md)
 
 ## Main Endpoint
@@ -98,12 +98,7 @@ Return codes:
 The creation of pool tasks is managed by the underline workflow system. No methods are exposed to manually trigger such creation to avoid workflow hjack and inconsistency.
 
 ## POST Method (single resource level)
-To claim a pool task a POST request must be issued against the single pool task URL
-/api/workflow/pooltasks/:id
-
-204 No content is returned if the request succeed
-403 Not authorized if the task cannot be claimed by the logged in user
-404 if the task is not longer available
+This method has been moved to the [claimed tasks](claimedtasks.md#post-method) resource.
 
 ## DELETE Method 
 Not allowed. To reset a workflow it is possible to issue a DELETE against the [workflowitem endpoint](workflowitem.md)

--- a/pooltasks.md
+++ b/pooltasks.md
@@ -98,7 +98,7 @@ Return codes:
 The creation of pool tasks is managed by the underline workflow system. No methods are exposed to manually trigger such creation to avoid workflow hjack and inconsistency.
 
 ## POST Method (single resource level)
-This method has been moved to the [claimed tasks](claimedtasks.md#post-method) resource.
+Not allowed. To claim a pool task, please POST against the [claimed tasks](claimedtasks.md#post-method) endpoint.
 
 ## DELETE Method 
 Not allowed. To reset a workflow it is possible to issue a DELETE against the [workflowitem endpoint](workflowitem.md)


### PR DESCRIPTION
https://github.com/DSpace/DSpace/pull/3054 moved the endpoint to claim a pool task to the claimed tasks resource. The pool tasks REST contract was still mentioning the defunct endpoint.