### PR TITLE
Old 6.x URL paths should redirect to new 7.x location (for SEO)

### DIFF
--- a/bitstreams.md
+++ b/bitstreams.md
@@ -115,6 +115,26 @@ The supported **Request Headers** are:
 * Range: not implemented yet. Provide support to partial content download
 * If-None-Match: not implemented yet. Support for cache control
 
+## Search methods
+### byItemHandle
+**/api/core/bitstreams/search/byItemHandle?handle=<:prefix>/<:suffix>&sequence=<:sequence_id>&filename=<:filename>**
+
+It returns the bitstream matching the given parameters, or an empty response
+
+The supported parameters are:
+* `handle`: mandatory, the item's handle
+* `sequence`: optional, the bitstream's sequence ID
+* `filename`: optional, the bitstream's file name
+* either `sequence` or `filename` should be present
+
+Return codes:
+* 200 OK - if the operation succeed. This will contain the bitstream
+* 204 No Content - if there is no bitstream matching the given parameters
+* 400 Bad Request - if neither `sequence` nor `filename` is present
+* 401 Unauthorized - if you are not authenticated and the bitstream metadata is not public
+* 403 Forbidden - if you are not logged in with sufficient permissions to see the bitstream metadata
+* 422 Unprocessable Entity - if the provided uuid cannot be resolved to an item regardless to the item status
+
 ## DELETE Method
 Delete a bitstream. Works for normal bitstreams in an Item (bundle), and a community or collection logo
 


### PR DESCRIPTION
This is the contract for https://github.com/DSpace/dspace-angular/issues/1147