### PR TITLE
Entities projections

### DIFF
--- a/items.md
+++ b/items.md
@@ -479,6 +479,30 @@ Provide version information based on a given Item UUID. An Item UUID will only m
 
 The JSON response and status codes are the same as the [Version endpoint](version.md#get-single-version).
 
+## Property-based projections
+
+[Property-based projections](projections.md#property-based-projections) can add new JSON properties to the response. When requesting the projection, any `item` in the response will add these properties.  
+The REST request doesn't have to be on the `item` endpoint directly, it can be on another endpoint which simply embeds items.
+
+### Verify whether there's a relationship with another given item
+**?projection=CheckRelatedItem&checkRelatedItem=<:other-item>**
+
+This is a projection for items, to indicate whether the item is related to the given item with the optional given relationship type.
+
+When using the `projection=CheckRelatedItem`, it is possible to check for related items.
+The parameter `checkRelatedItem` determines which items (and optionally which relationship types) should be checked.
+The parameter `checkRelatedItem` is repeatable, allowing for multiple items to be checked at once
+
+Sample values are:
+* `checkRelatedItem=f727a6a4-5541-4148-ad0a-1ab9596d981f`: check whether the current item has a relationship with item `f727a6a4-5541-4148-ad0a-1ab9596d981f`
+* `checkRelatedItem=isPublicationOfAuthor=f727a6a4-5541-4148-ad0a-1ab9596d981f`: check whether the current item has a relationship with item `f727a6a4-5541-4148-ad0a-1ab9596d981f` using relationship type `isPublicationOfAuthor`
+
+Response:
+* The response will contain an extra JSON property `relatedItems` in the item object
+* If there's no relationship to the given item, it will be an empty array: `relatedItems:[]`
+* If there is a relationship to the given item, it will contain the related item: `relatedItems:['f727a6a4-5541-4148-ad0a-1ab9596d981f']`
+* If multiple items are requested in `checkRelatedItem`, the property will contain all items which have a relationship
+
 ## Deleting an item
 
 **DELETE /api/core/items/<:uuid>**

--- a/projections.md
+++ b/projections.md
@@ -9,11 +9,15 @@ Projections may add to, modify, or omit information from the default representat
 When fulfilling a request, the active projection is applied to the primary resource being requested
 as well as any embedded resources.
 
-## Standard Projections
+## Projections which act on the embed section
+
+These projections will add information to the `_embedded` section of the HAL representation.
+
+### Standard Projections
 
 There are two standard projections available in all DSpace 7+ instances:
 
-### Default Projection
+#### Default Projection
 
 The _default_ projection makes no changes to the normal representation of the resource and **excludes all
 subresource embeds**, omitting altogether the `_embedded` section of the HAL representation.
@@ -21,14 +25,14 @@ subresource embeds**, omitting altogether the `_embedded` section of the HAL rep
 This is the implicit projection for all individual resource endpoints, such as `/api/core/items/<:uuid>`,
 if no projection is specified.
 
-### Full Projection (`?projection=full`)
+#### Full Projection (`?projection=full`)
 
 The _full_ projection includes all linked subresources also embedded in the response.
 
 Since embeds may include other embedded resources, it is important to limit the number of embed levels
 alloweds. Thus, only two levels of embeds will be returned at maximum when the _full_ projection is requested.
 
-## Custom Projections
+### Custom Projections
 
 Developers and integrators may extend the available projections for use with a DSpace instance by adding
 a new uniquely-named `Projection` as a Java Spring `@Component`, and ensuring it is deployed (e.g. as a jar)
@@ -40,7 +44,7 @@ REST API endpoints using the same syntax as the standard projections (`?projecti
 See [the Projection javadocs](https://github.com/DSpace/DSpace/blob/master/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java)
 for more information.
 
-## Specify Embed requests
+### Specify Embed requests
 
 All `GET` requests returning a HAL document support an optional *embed* argument, specifying the link path
 of information to be embedded.
@@ -52,7 +56,7 @@ as well as any embedded resources.
 
 All linked resources which allow embeds can be retrieved using the *embed* argument, they don't have to be configured
 
-### Basic embeds
+#### Basic embeds
 
 The most basic usage is to specify one level of embeds.
 This will allow `core/items/<:uuid>?embed=bundles&embed=owningCollection` to embed the bundles and the owningCollection of the item.
@@ -63,7 +67,7 @@ It won't embed the collections and subcommunities of subcommunities.
 
 The supported syntax is `core/items/{uuid}?embed=bundles&embed=owningCollection` or `core/items/{uuid}?embed=bundles,owningCollection`
 
-### Multi-level embeds
+#### Multi-level embeds
 
 In case there's a use case to embed sub-resources of a sub-resource, multi-level embeds can be used.
 
@@ -94,3 +98,37 @@ The request `/api/core/communities/<:uuid>?embed=subcommunities/subcommunities&e
 * The subcommunities of the subcommunities
 * The collections of the subcommunities
 * The community's collections
+
+
+## Property-based projections
+
+Property-based projections can add new JSON properties to the response. When requesting the projection, any matching object in the response may add these properties.
+
+### Standard Projections
+
+There are no standard property-based projections.
+
+### Custom Projections
+
+Some custom projections exist, e.g. on the [item](items.md#verify-whether-theres-a-relationship-with-another-given-item) or [relationships](relationships.md#verify-whether-a-given-item-is-the-left-or-right) endpoint.
+
+Developers and integrators may extend the available projections for use with a DSpace instance by adding
+a new uniquely-named `Projection` as a Java Spring `@Component`, and ensuring it is deployed (e.g. as a jar)
+within the DSpace server webapp.
+
+Upon successful component discovery, the projection will automatically become available for use with all
+REST API endpoints using the same syntax as the standard projections (`?projection=name`).
+
+See [the Projection javadocs](https://github.com/DSpace/DSpace/blob/master/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java)
+for more information.
+
+### HAL link impact of property-based projections
+
+Because property-based projections impact the JSON contents of the given record, the self-link will be impacted.  
+Any other links HAL links to this record will also be impacted.
+
+If there's a projection which adds a property `test` to the `item` if the `item` was requested using a custom projection,
+the response cannot be cached identical to the request without this projection.  
+This implies the HAL link to that item should contain the `projection` parameter, to clarify a cached version without that `projection` parameter is not valid.  
+This also implies the self link of that item should contain the same `projection` parameter.  
+If the projection used additional parameters to identify how it should be applied, those additional parameters should also be part of the HAL link.

--- a/relationships.md
+++ b/relationships.md
@@ -346,6 +346,30 @@ This can be further filtered to a single DSO using
 https://dspace7-entities.atmire.com/rest/#https://dspace7-entities.atmire.com/rest/api/core/relationships/search/byLabel?label=isPersonOfOrgUnit&dso=f2235aa6-6fe7-4174-a690-598b72dd8e44 which contains all relationships created using the relationship type isPersonOfOrgUnit for which one item is f2235aa6-6fe7-4174-a690-598b72dd8e44
 The dso parameter is optional
 
+## Property-based projections
+
+[Property-based projections](projections.md#property-based-projections) can add new JSON properties to the response. When requesting the projection, any `relationship` in the response will add these properties.  
+The REST request doesn't have to be on the `relationship` endpoint directly, it can be on another endpoint which simply embeds relationships.
+
+### Verify whether a given item is the left or right
+**?projection=CheckSideItemInRelationship&checkSideItemInRelationship=<:item-uuid>**
+
+This is a projection for relationships, to indicate on which side of the relationship the given item resides
+
+When using the `projection=CheckSideItemInRelationship`, it is possible to check on which side the given item resides.
+The parameter `checkSideItemInRelationship` determines which item should be checked.
+The parameter `checkSideItemInRelationship` is not repeatable.
+
+Sample value:
+* `checkSideItemInRelationship=f727a6a4-5541-4148-ad0a-1ab9596d981f`: check whether the current relationship contains the item `f727a6a4-5541-4148-ad0a-1ab9596d981f` on the left or right side
+
+Response:
+* The response will contain 2 extra JSON properties `relatedItemRight` and `relatedItemLeft` in the relationship object
+* Both new properties are booleans, defaulting to false
+* If the given item occurs on the left side, `relatedItemLeft` will be set to true
+* If the given item occurs on the right side, `relatedItemRight` will be set to true
+* If the given item doesn't occur, both will be false
+
 ## Deleting a relationship
 
 **DELETE /api/core/relationships/<:id>**

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -69,6 +69,50 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 
 The 2 [item types](itemtypes.md) are embedded
 
+## Search methods
+
+### Relationship types containing an entity type
+**/api/core/relationshiptypes/search/byEntityTypeId?id=<:entity-type-id>**
+
+Parameters:
+* The `id` should be the entity type id from the [entity types endpoint](entitytypes.md). It is mandatory. It can occur on either the left or right hand side
+
+A sample search would be /server/api/core/relationshiptypes/search/byEntityTypeId?id=1
+
+It would respond with
+```json
+{
+  "_embedded": {
+    "relationshiptypes": [
+      {
+        "id": 10,
+        "leftwardType": "isAuthorOfPublication",
+        "rightwardType": "isPublicationOfAuthor",
+        "copyToLeft": false,
+        "copyToRight": false,
+        "leftMinCardinality": 0,
+        "leftMaxCardinality": null,
+        "rightMinCardinality": 0,
+        "rightMaxCardinality": null,
+        "type": "relationshiptype"
+      },
+      {
+        "id": 1,
+        "leftwardType": "isAuthorOfPublication",
+        "rightwardType": "isPublicationOfAuthor",
+        "copyToLeft": false,
+        "copyToRight": false,
+        "leftMinCardinality": 0,
+        "leftMaxCardinality": null,
+        "rightMinCardinality": 0,
+        "rightMaxCardinality": null,
+        "type": "relationshiptype"
+      }
+    ]
+  }
+}
+```
+
 ## Property-based projections
 
 [Property-based projections](projections.md#property-based-projections) can add new JSON properties to the response. When requesting the projection, any `relationshiptype` in the response will add these properties.  

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -68,3 +68,27 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 ```
 
 The 2 [item types](itemtypes.md) are embedded
+
+## Property-based projections
+
+[Property-based projections](projections.md#property-based-projections) can add new JSON properties to the response. When requesting the projection, any `relationshiptype` in the response will add these properties.  
+The REST request doesn't have to be on the `relationshiptype` endpoint directly, it can be on another endpoint which simply embeds relationship types.
+
+### Verify whether a given entity type is the left or right
+**?projection=CheckSideEntityInRelationshipType&checkSideEntityInRelationshipType=<:entitytype>**
+
+This is a projection for relationship types, to indicate on which side of the relationship type the given entity type resides
+
+When using the `projection=CheckSideEntityInRelationshipType`, it is possible to check on which side the given entity type resides.
+The parameter `checkSideEntityInRelationshipType` determines which entity type should be checked.
+The parameter `checkSideEntityInRelationshipType` is not repeatable.
+
+Sample value:
+* `checkSideEntityInRelationshipType=Publication`: check whether the current relationship type contains the type `Publication` on the left or right side
+
+Response:
+* The response will contain 2 extra JSON properties `relatedTypeRight` and `relatedTypeLeft` in the relationship type object
+* Both new properties are booleans, defaulting to false
+* If the given entity type occurs on the left side, `relatedTypeLeft` will be set to true
+* If the given entity type occurs on the right side, `relatedTypeRight` will be set to true
+* If the given entity type doesn't occur, both will be false


### PR DESCRIPTION
This is the REST contract for the changes requested in https://github.com/DSpace/dspace-angular/issues/1148

It contains details of the new Projection type (for JSON properties), the 3 new Projections, and the new search method, all requested in this issue:

* A projection for items, to indicate whether the item is related to the given item with the given relationship type
* A projection for relationships, to indicate on which side of the relationship the given item resides
* A projection for relationshiptypes, to indicate on which side of the relationshiptype the given entity type resides
* A search endpoint for relationshiptypes, to search by entity type