### PR TITLE
Update items contract per PR#3321

### DIFF
--- a/items.md
+++ b/items.md
@@ -4,8 +4,9 @@
 ## Main Endpoint
 **/api/core/items**   
 
-Provide access to the items (DBMS based). It returns the list of existent items.
-This endpoint is reserved to the administrators the common practice is to navigate to the single items via a discovery search or browse
+Provide access to the items (DBMS based). This endpoint is reserved to the administrators the common practice is to navigate to the single items via a discovery [search](search-endpoint.md) or [browse](browses.md).
+
+Currently, this endpoint only returns "archived" items which are NOT withdrawn. However, withdrawn items and Workspace/Workflow items are findable via [search endpoints](search-endpoint.md). In the future, this endpoint is likely to be updated to include all items, regardless of status, see https://github.com/DSpace/DSpace/issues/3325
 
 Example: <https://api7.dspace.org/server/#/server/api/core/items>
 

--- a/items.md
+++ b/items.md
@@ -6,7 +6,7 @@
 
 Provide access to the items (DBMS based). This endpoint is reserved to the administrators the common practice is to navigate to the single items via a discovery [search](search-endpoint.md) or [browse](browses.md).
 
-Currently, this endpoint only returns "archived" items which are NOT withdrawn. However, withdrawn items and Workspace/Workflow items are findable via [search endpoints](search-endpoint.md). In the future, this endpoint is likely to be updated to include all items, regardless of status, see https://github.com/DSpace/DSpace/issues/3325
+Currently, this endpoint only returns "archived" items which are NOT withdrawn. However, withdrawn items and Workspace/Workflow items are findable via [search endpoints](search-endpoint.md). Template items are findable via the corresponding collection. In the future, this endpoint is likely to be updated to include all items, regardless of status, see https://github.com/DSpace/DSpace/issues/3325
 
 Example: <https://api7.dspace.org/server/#/server/api/core/items>
 


### PR DESCRIPTION
Document that the `/api/core/items` endpoint only returns "archived" items & link to ticket where that bug is described in more detail. 

See also https://github.com/DSpace/DSpace/pull/3321