### PR TITLE
Contract for item versioning

### DIFF
--- a/items.md
+++ b/items.md
@@ -473,12 +473,12 @@ Status codes:
 * 403 Forbidden - if you are not logged in with sufficient permissions
 * 404 Not found - if the item doesn't exist
 
-### Get single version for item
-**GET /api/core/items/{:item-uuid}/version**
+### Get version history for item
+**GET /api/core/items/{:item-uuid}/versionhistory**
 
-Provide version information based on a given Item UUID. An Item UUID will only match one version.
+Provide version history information based on a given Item UUID. An Item UUID will only match one version history.
 
-The JSON response and status codes are the same as the [Version endpoint](version.md#get-single-version).
+The JSON response and status codes are the same as the [Version History endpoint](versionhistory.md#get-version-history).
 
 ## Deleting an item
 

--- a/version.md
+++ b/version.md
@@ -135,7 +135,6 @@ Return codes:
 * 200 OK - if the operation succeeds
 * 401 Unauthorized - if you are not authenticated and versioning is not public
 * 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
-* 204 No Content - if there are no versions related to the specified history
 * 400 Bad Request - if the history id param is missing or invalid (not an Integer)
 
 ## Remove version

--- a/version.md
+++ b/version.md
@@ -9,7 +9,28 @@ If this is set to true, the version can only be retrieved if the user is an admi
 
 ## Create version
 
-TODO
+**POST /api/versioning/versions[?summary=<summary-text>]**
+
+* summary: it is an optional textual parameter that if provided will be saved in the summary property of the new version
+
+Item administrators or, according to the `versioning.submitterCanCreateNewVersion` configuration, the original submitter can create a new version of an item. The content-type is uri-list.
+
+The URI-list should contain the uri of the item that should be used to create the new version. It can be an item without an existing version history or an item part of an existing history. In the latest case it is possible to use an item representing an older version than the current one to facilitate the restore. 
+
+An example curl call:
+
+```
+ curl -i -X POST https://demo7.dspace.org/server/api/versioning/versions \
+ -H "Content-Type:text/uri-list" \
+ --data "https://demo7.dspace.org/server/api/core/items/a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9"
+```
+
+Status codes:
+* 200 OK - if the new version has been created
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions
+* 400 Bad Request - if the uri doesn't resolve to an item
+* 422 Unprocessable Entity - if there are already an inprogress submission representing a new version in the same version history of the item 
 
 ## Get single version
 
@@ -19,53 +40,144 @@ Provide version information for the version id.
 
 ```json
 {
-  "id": "102",
-  "version": "2",
+  "id": "345",
+  "version": "101",
   "type": "version",
   "created": "2015-11-03T09:44:46.617",
   "summary": "Fixing some typos in the abstract",
-  "submitterName": "LastName, FirstName",
   "_links": {
     "versionhistory": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/10"
+      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1"
     },
     "self": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versions/101"
+      "href": "https://demo7.dspace.org/server/api/versioning/versions/345"
     },
     "item": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versions/101/item"
+      "href": "https://demo7.dspace.org/server/api/versioning/versions/345/item"
     }
   }
-}
-```         
-
-The `submitterName` attribute is only exposed if you are logged in as an administrator or if the `versioning.item.history.include.submitter` configuration property is set to true.
+}         
+```
 
 Status codes:
 * 200 OK - if the version exists and is accessible by the current user
 * 401 Unauthorized - if you are not authenticated and versioning is not public
 * 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
-* 404 Not found - if the version doesn't exist
+* 404 Not found - if the version doesn't exist or was deleted
 
-## Get single version for item
+### Get single version for item
 
 **GET /api/core/items/{:item-uuid}/version**
 
 See [the item endpoint](items.md#get-single-version-for-item)
 
+### Search methods
+#### findByItem
+**/api/versioning/versions/search/findByItem**
+
+The supported parameters are:
+* `itemUuid`: mandatory, the item uuid
+
+It returns the single version, if any, related to the specified item.
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated and versioning is not public
+* 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
+* 204 No Content - if the specified item is not yet versioned
+* 400 Bad Request - if the item id param is missing or invalid (not an uuid)
+
+#### findByHistory
+**/api/versioning/versions/search/findByHistory**
+
+The supported parameters are:
+* `historyId`: mandatory, the version history id
+* `page`, `size` [see pagination](README.md#Pagination)
+
+It returns a pageable list of not yet deleted versions for the provided version history identifier.  
+The versions are ordered by version number descending.
+
+```json
+{
+  "_embedded": {
+    "versions": [
+      {
+          "id": "102",
+          "version": "2",
+          "type": "version",
+          "created": "2019-10-31T09:44:46.617",
+          "summary": "Author order"
+      },
+      {
+        "id": "101",
+        "version": "1",
+        "type": "version",
+        "created": "2015-11-03T09:44:46.617",
+        "summary": "Fixing some typos in the abstract"
+      }
+    ],
+    "_links": {
+     "self": {
+       "href": "https://demo7.dspace.org/server/api/versioning/versions/search/findByHistory?historyId=1"
+     }
+    },
+    "page": {
+     "size": 20,
+     "totalElements": 2,
+     "totalPages": 1,
+     "number": 0
+    }
+  }
+}
+```
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated and versioning is not public
+* 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
+* 204 No Content - if there are no versions related to the specified history
+* 400 Bad Request - if the history id param is missing or invalid (not an Integer)
+
 ## Remove version
 
-TODO
+**DELETE /api/versioning/versions/<:versionId>**
 
-## Update version
+Delete a version item.
 
-TODO
+Return codes:
+* 204 No content - if the operation succeed
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions
+* 404 Not found - if the item doesn't exist (or was already deleted)
+
+## Update version (patch operations)
+
+Only the summary property can be updated by item administrators, all the other properties are **READ-ONLY**. Attempt to update any other information will result in a 422 error.
+
+To update the metadata of the corresponding item the appropriate method in the items, workspaceitems or workflowitems endpoints need to be used according to the item status.
+
+**PATCH **
+
+To update the summary property a patch request over the `/summary` path is needed.
+According to the [general patch rules](patch.md)
+To nullify a summary use the `"op": "remove"` patch operation
+To replace an existing summary use the `"op": "replace"` or `"op": "add"` patch operation
+To set a summary value when the summary is null use the `"op": "add"` patch operation
+
+For example, `curl -X PATCH http://${dspace.url}/api/versioning/versions/<:id-version> -H "Content-Type: application/json" -d '[{ "op": "add", "path": "/summary", "value": "This is the note related to the version"]'`.  The operation also requires an Authorization header.
+
+Return codes:
+* 200 Ok - if the operation succeed
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions
+* 404 Not found - if the version doesn't exist (or was deleted)
+* other error codes according to the [general patch operation rules](patch.md)
 
 ## Linked entities
 
 ### Version History
 
-Retrieves the relation versions, for details see [Version history](versionhistory.md)
+Retrieves the related version history, for details see [Version history](versionhistory.md)
 
 ### Item
 

--- a/version.md
+++ b/version.md
@@ -15,7 +15,9 @@ If this is set to true, the version can only be retrieved if the user is an admi
 
 Item administrators or, according to the `versioning.submitterCanCreateNewVersion` configuration, the original submitter can create a new version of an item. The content-type is uri-list.
 
-The URI-list should contain the uri of the item that should be used to create the new version. It can be an item without an existing version history or an item part of an existing history. In the latest case it is possible to use an item representing an older version than the current one to facilitate the restore. 
+The URI-list should contain the uri of the item that should be used to create the new version. It can be an item without an existing version history or an item part of an existing history. In the latest case it is possible to use an item representing an older version than the current one to facilitate the restore.
+
+The new created version will be returned in the response, see the [get single version](#get-single-version) endpoint for an example of response.
 
 An example curl call:
 
@@ -26,7 +28,7 @@ An example curl call:
 ```
 
 Status codes:
-* 200 OK - if the new version has been created
+* 201 Created - if the new version has been created
 * 401 Unauthorized - if you are not authenticated
 * 403 Forbidden - if you are not logged in with sufficient permissions
 * 400 Bad Request - if the uri doesn't resolve to an item
@@ -45,6 +47,7 @@ Provide version information for the version id.
   "type": "version",
   "created": "2015-11-03T09:44:46.617",
   "summary": "Fixing some typos in the abstract",
+  "submitterName": "LastName, FirstName",
   "_links": {
     "versionhistory": {
       "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1"
@@ -58,6 +61,8 @@ Provide version information for the version id.
   }
 }         
 ```
+
+The `submitterName` attribute is only exposed if you are logged in as an administrator or if the `versioning.item.history.include.submitter` configuration property is set to true.
 
 Status codes:
 * 200 OK - if the version exists and is accessible by the current user

--- a/versionhistory.md
+++ b/versionhistory.md
@@ -2,7 +2,7 @@
 
 [Back to the list of all defined endpoints](endpoints.md)
 
-This endpoint represents all related versions.
+This endpoint represents the version history that group all related versions.
 
 Whether version history information is accessible depends on versioning.item.history.view.admin configuration
 If this is set to true, the version history can only be retrieved if the user is an admin of the last version's item
@@ -19,10 +19,16 @@ Provide version information for the version history id.
   "type": "versionhistory",
   "_links": {
     "self": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/1"
+      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1"
     },
-    "versions": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/1/versions"
+    "oldestversion": {
+      "href": "https://demo7.dspace.org/server/api/versioning/versions/1"
+    },
+    "currentversion": {
+      "href": "https://demo7.dspace.org/server/api/versioning/versions/100"
+    },
+    "lastversion": {
+      "href": "https://demo7.dspace.org/server/api/versioning/versions/101"
     }
   }
 }
@@ -32,47 +38,28 @@ Status codes:
 * 200 OK - if the version history exists and is accessible by the current user
 * 401 Unauthorized - if you are not authenticated and versioning is not public
 * 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
-* 404 Not found - if the version history doesn't exist
+* 404 Not found - if you have the permission to review the version history and it doesn't exist
 
 ## Linked entities
 
+### Oldest Version
+
+**GET /api/versioning/versionhistories/<:versionHistoryId>/oldestversion**
+
+Retrieve the oldest version in the history 
+
+### Current Version
+
+**GET /api/versioning/versionhistories/<:versionHistoryId>/currentversion**
+
+Retrieve the most recent archived version in the history
+
+### Last Version
+
+**GET /api/versioning/versionhistories/<:versionHistoryId>/lastversion**
+
+Retrieve the most recent version in the history that could live eventually in the workspace or workflow 
+
 ### Versions
 
-**GET /api/versioning/versionhistories/<:versionHistoryId>/versions**
-
-Retrieve a pageable list of versions for the provided version history identifier.  
-The versions are ordered by version number descending.
-
-```json
-{
-  "_embedded": {
-    "versions": [
-      {
-          "id": "102",
-          "version": "2",
-          "type": "version",
-          "created": "2019-10-31T09:44:46.617",
-          "summary": "Author order"
-      },
-      {
-        "id": "101",
-        "version": "1",
-        "type": "version",
-        "created": "2015-11-03T09:44:46.617",
-        "summary": "Fixing some typos in the abstract"
-      }
-    ],
-    "_links": {
-     "self": {
-       "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/1/versions"
-     }
-    },
-    "page": {
-     "size": 20,
-     "totalElements": 2,
-     "totalPages": 1,
-     "number": 0
-    }
-  }
-}
-```
+To avoid a bidirectional link between the versions and the history that they belong to a search method is available in the [version endpoint](version.md) to retrieve all the versions by history id


### PR DESCRIPTION
This contract includes the changes needed to support the item versioning in DSpace 7 as by https://github.com/DSpace/DSpace/issues/2844

The original version and versionhistory contract were just an old (2 years ago) draft.

The change in the items endpoint is to avoid a bidirectional reference between item and version. The item now has a link to versionhistory as this make easier to embed the minimal information that are always needed on UI to show an info box if you are looking to an older version of the content or to trigger the visualization of an history. A search method in the version endpoint is proposed to allow to retrieve the version details related to a specific item if needed.