### PR TITLE
Additional search methods for relationships

### DIFF
--- a/relationships.md
+++ b/relationships.md
@@ -97,19 +97,26 @@ An optional leftwardValue and rightwardValue property can be present. It's omitt
 ## Search methods
 
 ### Relationship involving specified items
-**/api/core/relationships/search/byItemsAndType?typeId=<:relationship-type-id>&leftItem=<item-uuid1>[&...&&leftItem=<item-uuidN>]&rightItem=<item-uuid1>[&...&&rightItem=<item-uuidN>]**
+**/api/core/relationships/search/byItemsAndType?typeId=<:relationship-type-id>&relationshipLabel=<:relationship-label>&focusItem=<:item-uuid>&relatedItem=<:item-uuid1>[&...&&relatedItem=<:item-uuidN>]**
 
 This method is intended to be used when giving an item (focus) and a list of potentially related items we need to know which of these other items are already in a specific relationship with the focus item and, by exclusion which ones are not yet related.
 
 The supported parameters are:
 * page, size [see pagination](README.md#Pagination)
 * typeId: mandatory, the relationship type id to apply as a filter to the returned relationships
-* leftItem; mandatory, repeatable if the rightItem parameter is not repeated. The uuid of the items to be checked on the left side of returned relationships
-* rightItem; mandatory, repeatable if the leftItem parameter is not repeated. The uuid of the items to be found on the right side of returned relationships
+* relationshipLabel: mandatory, the name of the relation as defined from the side of the `focusItem`
+* focusItem; mandatory. The uuid of the item to be checked on the side defined by `relationshipLabel`
+* relatedItem; mandatory, repeatable. The uuid of the items to be found on the other side of returned relationships
 
+For example the request
+```/api/core/relationships/search/byItemsAndType?typeId=<:type-id>&relationshipLable=isAuthorOfPublication&focusItem=<:publication-uuid>&relatedItem=<:one-person-uuid>&relatedItem=<:two-person-uuid>&relatedItem=<:three-person-uuid>```
+
+would return a list of relationship with the specified publication (focusItem) on the left side (as isAuthorOfPublication is the leftwardType of the relationshiptype with typeId) and on the right side there is one of the specified person (relatedItem params).
+ 
 Return codes:
 * 200 OK - if the operation succeed. This include the case of no matching relationships where a 0-size page json representation is returned.
-* 400 Bad Request - if the type parameter, leftItem and rightItem parameters are missing or invalid or multiple values are provided for both the leftItem and rightItem parameters
+* 400 Bad Request - if one of the parameters is missing or syntactically invalid (i.e. not an uuid, integer) 
+* 422 Unprocessable Entity - if the focusSide doesn't match the relationship type.
 
 ## Creating a relationship
 

--- a/relationships.md
+++ b/relationships.md
@@ -97,7 +97,7 @@ An optional leftwardValue and rightwardValue property can be present. It's omitt
 ## Search methods
 
 ### Relationship involving specified items
-**/api/core/relationshiptypes/search/byItemsAndType?typeId=<:relationship-type-id>&leftItem=<item-uuid1>[&...&&leftItem=<item-uuidN>]&rightItem=<item-uuid1>[&...&&rightItem=<item-uuidN>]**
+**/api/core/relationships/search/byItemsAndType?typeId=<:relationship-type-id>&leftItem=<item-uuid1>[&...&&leftItem=<item-uuidN>]&rightItem=<item-uuid1>[&...&&rightItem=<item-uuidN>]**
 
 This method is intended to be used when giving an item (focus) and a list of potentially related items we need to know which of these other items are already in a specific relationship with the focus item and, by exclusion which ones are not yet related.
 

--- a/relationships.md
+++ b/relationships.md
@@ -109,14 +109,14 @@ The supported parameters are:
 * relatedItem; mandatory, repeatable. The uuid of the items to be found on the other side of returned relationships
 
 For example the request
-```/api/core/relationships/search/byItemsAndType?typeId=<:type-id>&relationshipLable=isAuthorOfPublication&focusItem=<:publication-uuid>&relatedItem=<:one-person-uuid>&relatedItem=<:two-person-uuid>&relatedItem=<:three-person-uuid>```
+```/api/core/relationships/search/byItemsAndType?typeId=<:type-id>&relationshipLabel=isAuthorOfPublication&focusItem=<:publication-uuid>&relatedItem=<:one-person-uuid>&relatedItem=<:two-person-uuid>&relatedItem=<:three-person-uuid>```
 
 would return a list of relationship with the specified publication (focusItem) on the left side (as isAuthorOfPublication is the leftwardType of the relationshiptype with typeId) and on the right side there is one of the specified person (relatedItem params).
  
 Return codes:
 * 200 OK - if the operation succeed. This include the case of no matching relationships where a 0-size page json representation is returned.
 * 400 Bad Request - if one of the parameters is missing or syntactically invalid (i.e. not an uuid, integer) 
-* 422 Unprocessable Entity - if the focusSide doesn't match the relationship type.
+* 422 Unprocessable Entity - if the relationshipLabel doesn't match the relationship type.
 
 ## Creating a relationship
 

--- a/relationships.md
+++ b/relationships.md
@@ -94,6 +94,23 @@ The 2 items are included as HAL links but are not embedded
 
 An optional leftwardValue and rightwardValue property can be present. It's omitted when it's null.
 
+## Search methods
+
+### Relationship involving specified items
+**/api/core/relationshiptypes/search/byItemsAndType?typeId=<:relationship-type-id>&leftItem=<item-uuid1>[&...&&leftItem=<item-uuidN>]&rightItem=<item-uuid1>[&...&&rightItem=<item-uuidN>]**
+
+This method is intended to be used when giving an item (focus) and a list of potentially related items we need to know which of these other items are already in a specific relationship with the focus item and, by exclusion which ones are not yet related.
+
+The supported parameters are:
+* page, size [see pagination](README.md#Pagination)
+* typeId: mandatory, the relationship type id to apply as a filter to the returned relationships
+* leftItem; mandatory, repeatable if the rightItem parameter is not repeated. The uuid of the items to be checked on the left side of returned relationships
+* rightItem; mandatory, repeatable if the leftItem parameter is not repeated. The uuid of the items to be found on the right side of returned relationships
+
+Return codes:
+* 200 OK - if the operation succeed. This include the case of no matching relationships where a 0-size page json representation is returned.
+* 400 Bad Request - if the type parameter, leftItem and rightItem parameters are missing or invalid or multiple values are provided for both the leftItem and rightItem parameters
+
 ## Creating a relationship
 
 **POST /api/core/relationships?relationshipType=<:relationshipType>**

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -68,3 +68,51 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 ```
 
 The 2 [item types](itemtypes.md) are embedded
+
+## Search methods
+
+### Relationship types containing an entity type
+**/api/core/relationshiptypes/search/byEntityType?type=<:entity-type-label>**
+
+Parameters:
+* The `type` should be the entity type label from the [entity types endpoint](entitytypes.md). It is mandatory. It can occur on either the left or right hand side
+
+A sample search would be /server/api/core/relationshiptypes/search/byEntityType?id=Publication
+
+It would respond with
+```json
+{
+  "_embedded": {
+    "relationshiptypes": [
+      {
+        "id": 10,
+        "leftwardType": "isAuthorOfPublication",
+        "rightwardType": "isPublicationOfAuthor",
+        "copyToLeft": false,
+        "copyToRight": false,
+        "leftMinCardinality": 0,
+        "leftMaxCardinality": null,
+        "rightMinCardinality": 0,
+        "rightMaxCardinality": null,
+        "type": "relationshiptype"
+      },
+      {
+        "id": 1,
+        "leftwardType": "isAuthorOfPublication",
+        "rightwardType": "isPublicationOfAuthor",
+        "copyToLeft": false,
+        "copyToRight": false,
+        "leftMinCardinality": 0,
+        "leftMaxCardinality": null,
+        "rightMinCardinality": 0,
+        "rightMaxCardinality": null,
+        "type": "relationshiptype"
+      }
+    ]
+  }
+}
+```
+
+Return codes:
+* 200 OK - if the operation succeed. This include the case of no matching relationship where a 0-size page json representation is returned.
+* 400 Bad Request - if the type parameter is missing or invalid

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -98,8 +98,8 @@ It would respond with
       },
       {
         "id": 1,
-        "leftwardType": "isAuthorOfPublication",
-        "rightwardType": "isPublicationOfAuthor",
+        "leftwardType": "isProjectOfPerson",
+        "rightwardType": "isPersonOfProject",
         "copyToLeft": false,
         "copyToRight": false,
         "leftMinCardinality": 0,

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -77,14 +77,15 @@ The 2 [item types](itemtypes.md) are embedded
 Parameters:
 * The `type` should be the entity type label from the [entity types endpoint](entitytypes.md). It is mandatory. It can occur on either the left or right hand side
 
-A sample search would be /server/api/core/relationshiptypes/search/byEntityType?id=Publication
+A sample search would be `/server/api/core/relationshiptypes/search/byEntityType?type=Publication'
 
-It would respond with
+Assuming that the sample `config/entities/relationship-types.xml` data model has been loaded, it would respond with
+
 ```json
 {
   "_embedded": {
     "relationshiptypes": [
-      {
+      { // it is between Person and Publication
         "id": 10,
         "leftwardType": "isAuthorOfPublication",
         "rightwardType": "isPublicationOfAuthor",
@@ -98,8 +99,8 @@ It would respond with
       },
       {
         "id": 1,
-        "leftwardType": "isProjectOfPerson",
-        "rightwardType": "isPersonOfProject",
+        "leftwardType": "isProjectOfPublication",
+        "rightwardType": "isPublicationOfProject",
         "copyToLeft": false,
         "copyToRight": false,
         "leftMinCardinality": 0,
@@ -107,11 +108,49 @@ It would respond with
         "rightMinCardinality": 0,
         "rightMaxCardinality": null,
         "type": "relationshiptype"
-      }
+      },
+      {
+        "id": 7,
+        "leftwardType": "isOrgUnitOfPublication",
+        "rightwardType": "isPublicationOfOrgUnit",
+        "copyToLeft": false,
+        "copyToRight": false,
+        "leftMinCardinality": 0,
+        "leftMaxCardinality": null,
+        "rightMinCardinality": 0,
+        "rightMaxCardinality": null,
+        "type": "relationshiptype"
+      },
+      { // this is a different relationshipttype than the one with id 10
+        // as it is about Publication and OrgUnit
+        "id": 17,
+        "leftwardType": "isAuthorOfPublication",
+        "rightwardType": "isPublicationOfAuthor",
+        "copyToLeft": false,
+        "copyToRight": false,
+        "leftMinCardinality": 0,
+        "leftMaxCardinality": null,
+        "rightMinCardinality": 0,
+        "rightMaxCardinality": null,
+        "type": "relationshiptype"
+      },
+      {
+        "id": 18, 
+        "leftwardType": "isPublicationOfJournalIssue",
+        "rightwardType": "isJournalIssueOfPublication",
+        "copyToLeft": false,
+        "copyToRight": false,
+        "leftMinCardinality": 0,
+        "leftMaxCardinality": null,
+        "rightMinCardinality": 0,
+        "rightMaxCardinality": null,
+        "type": "relationshiptype"
+      }    
     ]
   }
 }
 ```
+comments inside the above json are only included for clarity but are not part of the real response.
 
 Return codes:
 * 200 OK - if the operation succeed. This include the case of no matching relationship where a 0-size page json representation is returned.


### PR DESCRIPTION
This PR is the result of the discussion in https://github.com/DSpace/RestContract/pull/165

It provides an additional search methods for the relationship endpoint that will avoid the need to introduce a new type of projection.

Please note that the change in the relationshiptypes endpoint is very similar to the one in the above PR with the difference that the entity name is used as search parameter. This should in our opinion avoid a request in the scenario that need to be supported on the angular UI (DSpace/dspace-angular#1148) as the UI already know the item where the admin need to manage the relationships, this mean that the entity label is known but not necessary the Id. The entity label is de-facto a business id that cannot change in a easy way as it is stored in the item metadata.