### PR TITLE
Complete the version and version history endpoints

### DIFF
--- a/items.md
+++ b/items.md
@@ -476,9 +476,15 @@ Status codes:
 ### Get single version for item
 **GET /api/core/items/{:item-uuid}/version**
 
-Provide version information based on a given Item UUID. An Item UUID will only match one version.
+Provide version information based on a given Item UUID. An Item UUID will only match one version. READ permissions over the item in addition to the version permissions are checked.
+The JSON response is the same as the [Version endpoint](version.md#get-single-version).
 
-The JSON response and status codes are the same as the [Version endpoint](version.md#get-single-version).
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated and versioning is not public
+* 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
+* 204 No Content - if the specified item is not yet versioned
+* 400 Bad Request - if the item id param is missing or invalid (not an uuid)
 
 ## Deleting an item
 

--- a/version.md
+++ b/version.md
@@ -9,6 +9,8 @@ If this is set to true, the version can only be retrieved if the user is a commu
 Please note that the security of the single version is in no way related to the linked item. 
 It is eventually possible to retrieve a version related to a not accessible item, as the version doesn't expose any sensitive information this pose no security risks.
 
+**WARNING**: this feature currently address only normal DSpace item, by default, it cannot be used with Entity item (`versioning.block.entity = true'). The versioning feature is not considered complete for Entity items as the relationships are currently ignored when new version are created but the decision about how to deal with them is undergoing. The related authorization features: canManageVersions, canCreateVersion, canEditVersion, canDeleteVersion, if the versioning for entity is disallowed will always return false
+
 ## Main Endpoint
 **/api/versioning/versions**   
 
@@ -40,7 +42,7 @@ An example curl call:
 Status codes:
 * 201 Created - if the new version has been created
 * 401 Unauthorized - if you are not authenticated
-* 403 Forbidden - if you are not logged in with sufficient permissions
+* 403 Forbidden - if you are not logged in with sufficient permissions or if you are trying to create a new version for an entity item and the `versioning.block.entity` configuration property is `true` or unset
 * 400 Bad Request - if the uri doesn't resolve to an item
 * 422 Unprocessable Entity - if there are already an inprogress submission representing a new version in the same version history of the item 
 

--- a/version.md
+++ b/version.md
@@ -96,7 +96,7 @@ Only the summary property can be updated by item administrators, all the other p
 
 To update the metadata of the corresponding item the appropriate method in the items, workspaceitems or workflowitems endpoints need to be used according to the item status.
 
-**PATCH **
+**PATCH**
 
 To update the summary property a patch request over the `/summary` path is needed.
 According to the [general patch rules](patch.md)

--- a/version.md
+++ b/version.md
@@ -2,70 +2,122 @@
 
 [Back to the list of all defined endpoints](endpoints.md)
 
-This endpoint represents a single version, matching a single item.
+This endpoint provide access to a single version, matching a single item.
 
 Whether a version is accessible depends on `versioning.item.history.view.admin` configuration.  
-If this is set to true, the version can only be retrieved if the user is an admin of the related item
+If this is set to true, the version can only be retrieved if the user is a community, collection or repository administrator, otherwise the versions are public.
+Please note that the security of the single version is in no way related to the linked item. 
+It is eventually possible to retrieve a version related to a not accessible item, as the version doesn't expose any sensitive information this pose no security risks.
+
+## Main Endpoint
+**/api/versioning/versions**   
+
+_Unsupported._ Versions can only be navigated starting from a specific item, version history or accessed directly by id
+
+Status codes:
+* 405 Method Not Allowed
 
 ## Create version
 
-TODO
+**POST /api/versioning/versions[?summary=<summary-text>]**
+
+* summary: it is an optional textual parameter that if provided will be saved in the summary property of the new version
+
+Item administrators or, according to the `versioning.submitterCanCreateNewVersion` configuration, the original submitter can create a new version of an item. The content-type is uri-list.
+
+The URI-list should contain the uri of the item that should be used to create the new version. It can be an item without an existing version history or an item part of an existing history. In the latest case it is possible to use an item representing an older version than the current one to facilitate the restore.
+
+The new created version will be returned in the response, see the [get single version](#get-single-version) endpoint for an example of response.
+
+An example curl call:
+
+```
+ curl -i -X POST https://demo7.dspace.org/server/api/versioning/versions \
+ -H "Content-Type:text/uri-list" \
+ --data "https://demo7.dspace.org/server/api/core/items/a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9"
+```
+
+Status codes:
+* 201 Created - if the new version has been created
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions
+* 400 Bad Request - if the uri doesn't resolve to an item
+* 422 Unprocessable Entity - if there are already an inprogress submission representing a new version in the same version history of the item 
 
 ## Get single version
 
 **GET /api/versioning/versions/<:versionId>**
 
-Provide version information for the version id.
+Provide the version information associated to a specific id. The returned attributes depend on the user permissions and system configuration.
+The following example shows all the available attributes as exposed to an administrator
 
 ```json
 {
-  "id": "102",
-  "version": "2",
+  "id": "345",
+  "version": "101",
   "type": "version",
   "created": "2015-11-03T09:44:46.617",
   "summary": "Fixing some typos in the abstract",
   "submitterName": "LastName, FirstName",
   "_links": {
     "versionhistory": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/10"
+      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1"
     },
     "self": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versions/101"
+      "href": "https://demo7.dspace.org/server/api/versioning/versions/345"
     },
     "item": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versions/101/item"
+      "href": "https://demo7.dspace.org/server/api/versioning/versions/345/item"
     }
   }
-}
-```         
+}         
+```
 
-The `submitterName` attribute is only exposed if you are logged in as an administrator or if the `versioning.item.history.include.submitter` configuration property is set to true.
+The `submitterName` attribute is only exposed if you are logged in as an administrator of the linked item or if the `versioning.item.history.include.submitter` configuration property is set to true.
 
 Status codes:
 * 200 OK - if the version exists and is accessible by the current user
 * 401 Unauthorized - if you are not authenticated and versioning is not public
 * 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
-* 404 Not found - if the version doesn't exist
+* 404 Not found - if the version doesn't exist or was deleted
 
-## Get single version for item
-
-**GET /api/core/items/{:item-uuid}/version**
-
-See [the item endpoint](items.md#get-single-version-for-item)
+### Get single version for item
+Please follow the version link in [the item endpoint](items.md#get-single-version-for-item)
 
 ## Remove version
 
-TODO
+**DELETE /api/versioning/versions/<:versionId>**
 
-## Update version
+To delete a version you need to [delete the item](items.md#deleting-an-item) linked to it.
 
-TODO
+## Update version (patch operations)
+
+Only the summary property can be updated by item administrators, all the other properties are **READ-ONLY**. Attempt to update any other information will result in a 422 error.
+
+To update the metadata of the corresponding item the appropriate method in the items, workspaceitems or workflowitems endpoints need to be used according to the item status.
+
+**PATCH **
+
+To update the summary property a patch request over the `/summary` path is needed.
+According to the [general patch rules](patch.md)
+To nullify a summary use the `"op": "remove"` patch operation
+To replace an existing summary use the `"op": "replace"` or `"op": "add"` patch operation
+To set a summary value when the summary is null use the `"op": "add"` patch operation
+
+For example, `curl -X PATCH http://${dspace.url}/api/versioning/versions/<:id-version> -H "Content-Type: application/json" -d '[{ "op": "add", "path": "/summary", "value": "This is the note related to the version"]'`.  The operation also requires an Authorization header.
+
+Return codes:
+* 200 Ok - if the operation succeed
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions
+* 404 Not found - if the version doesn't exist (or was deleted)
+* other error codes according to the [general patch operation rules](patch.md)
 
 ## Linked entities
 
 ### Version History
 
-Retrieves the relation versions, for details see [Version history](versionhistory.md)
+Retrieves the related version history, for details see [Version history](versionhistory.md)
 
 ### Item
 

--- a/versionhistory.md
+++ b/versionhistory.md
@@ -2,37 +2,53 @@
 
 [Back to the list of all defined endpoints](endpoints.md)
 
-This endpoint represents all related versions.
+This endpoint represents the version history that group all related versions.
 
 Whether version history information is accessible depends on versioning.item.history.view.admin configuration
-If this is set to true, the version history can only be retrieved if the user is an admin of the last version's item
+If this is set to true, the version history can only be retrieved if the user is a community, collection or repository administrator, otherwise the version histories are public.
+Please note that the security of the version history is in no way related to any of the items that belong to it. 
+It is eventually possible to retrieve an history containing only not accessible items. As the version history neither the single version expose any sensitive information this pose no security risks.
+
+## Main Endpoint
+**/api/versioning/versionhistories**   
+
+_Unsupported._ Version histories can only be navigated starting from a specific version item or accessed directly by id
+
+Status codes:
+* 405 Method Not Allowed
 
 ## Get version history
 
 **GET /api/versioning/versionhistories/<:versionHistoryId>**
 
-Provide version information for the version history id.
+Provide information about for a version history id.
 
 ```json
 {
   "id": "1",
-  "type": "versionhistory",
+  "draftVersion": false,
+  "type": "versionhistory",  
   "_links": {
     "self": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/1"
+      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1"
     },
     "versions": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/1/versions"
+      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1/versions"
+    },
+    "draftVersion": {
+      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1/draftVersion"
     }
   }
 }
 ```
+Attributes:
+- draftVersion: true, if the most recent version is associated to an item still in progress (workspace or workflow), false otherwise. This attribute is only visible to users allowed to create a new version in the history, see [Create version endpoint](version.md#Create version) 
 
 Status codes:
 * 200 OK - if the version history exists and is accessible by the current user
 * 401 Unauthorized - if you are not authenticated and versioning is not public
 * 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
-* 404 Not found - if the version history doesn't exist
+* 404 Not found - if you have the permission to review the version history and it doesn't exist
 
 ## Linked entities
 
@@ -41,7 +57,8 @@ Status codes:
 **GET /api/versioning/versionhistories/<:versionHistoryId>/versions**
 
 Retrieve a pageable list of versions for the provided version history identifier.  
-The versions are ordered by version number descending.
+The versions are ordered by version number descending and attributes are secured as described in the [get single version endpoint](version.md#get-single-version).
+Only versions related to archived or withdrawn items are return, the most recent version will be excluded from this list if it is not yet archived.
 
 ```json
 {
@@ -64,7 +81,7 @@ The versions are ordered by version number descending.
     ],
     "_links": {
      "self": {
-       "href": "https://dspace7.4science.it/dspace-spring-rest/api/versioning/versionhistories/1/versions"
+       "href": "https://demo7.dspace.org/server/api/versioning/versions/search/findByHistory?historyId=1"
      }
     },
     "page": {
@@ -76,3 +93,17 @@ The versions are ordered by version number descending.
   }
 }
 ```
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated and versioning is not public
+* 403 Forbidden - if you are not logged in with sufficient permissions and versioning is not public
+
+### draftVersion
+
+**GET /api/versioning/versionhistories/<:versionHistoryId>/draftVersion**
+
+If the latest version is not yet archived, provide access to the workspaceitem or workflowitem associated with it.
+The link will respect the security defined in the workspaceitem or workflowitem endpoint so it could be not visible to user otherwise allowed to create a new version in the history.
+For this scenario the `draftVersion` flag allows the UI to turn off the "create new version" button. 
+Due to the restriction applied to this flag anonymous users will be unable to discover that a new version is currently under review.


### PR DESCRIPTION
This rest contract add the capabilities to create, delete and edit versions (only the summary information).

It is aimed to introduce the needed REST API to support the implementation of all the versioning features available before DSpace 7 and required in https://github.com/DSpace/RestContract/pull/167

It is an alternative to the https://github.com/DSpace/RestContract/pull/167
Indeed, from the discussion in the other PR we get the idea to rethink our design keeping almost untouched (backward compatible) the access endpoints that were already defined.

Please note that redesigning the endpoint and having learned some caveau from the first draft implementation that we had started https://github.com/DSpace/DSpace/pull/3371 we noted that it was required to detail better the security for these endpoints.

What is here proposed match with the implementation observed in previous DSpace versions. It is an edge scenario but it is possible that versions have different permissions. For example
version 1 can be READ anonymous
version 2 can be restricted to administrators
version 3 can be READ anonymous again
etc.

if the an anonymous user access version 1 or version 3 and versioning is not reserved to the admins he will see the full list of versions but the version table doesn't contain any information about the items itself other than the handle (that can be easily predicted in any case). If the user click on a reserved version the login/forbidden message is prompt.
With the proposed contract it will be almost the same except that the handle will be not shown but the access link can be provided under the version number.

Finally, I have left out of this pr any discussion about the interaction between entities and versioning as this can be discussed and clarified in a followup PR, the concept here would stay valid whatever approach we will decide to take