### PR TITLE
Embargo Item Metadata contract

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -24,6 +24,7 @@
 * [/api/config/submissionsections](submissionsections.md)
 * [/api/config/submissionforms](submissionforms.md)
 * [/api/config/submissionuploads](submissionuploads.md)
+* [/api/config/submissionaccesses](submissionaccesses.md)
 * [/api/config/workflowdefinitions](workflowdefinitions.md)
 * [/api/config/workflowsteps](workflowsteps.md)
 * [/api/discover/browses](browses.md)

--- a/submissionaccesses.md
+++ b/submissionaccesses.md
@@ -1,0 +1,48 @@
+# SubmissionAccesses Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+## Main Endpoint
+**/api/config/submissionaccesses**   
+
+Provide access to the existent configurations for the submission access. It returns the list of existent SubmissionAccessConfig.
+The SubmissionAccessConfig aggregates in a single place the configuration needed to the access section.
+
+## Single Submission-Form 
+**/api/config/submissionaccesses/<:access-name>**
+
+*:access-name* the access configuration name to retrieve
+
+Provide detailed information about a specific input-form. The JSON response document is as follows:
+```json
+{
+  "id": "default",
+  "private": true,
+  "accessConditionOptions": [
+		{
+ 			"name": "openaccess"
+		},
+		{
+ 			"name": "administrator"
+		},  	 			
+		{
+ 			"name": "embargo",
+ 			"hasStartDate": true,
+ 			"maxStartDate": "2018-06-24T00:40:54.970+0000"
+		},
+		{
+ 			"name": "lease",
+ 			"hasEndDate": true,
+ 			"maxEndDate": "2017-12-24T00:40:54.970+0000"
+		}
+  ]
+}
+
+```
+The **private** flag indicates whether or not the user has the opportunity to indicate that the current item must be private, i.e. not searchable
+
+The attributes of the objects in the **accessConditionOptions** arrays are as follow:
+* The *name* attribute is an identifier that can be used by the REST client (the UI) to present the different options to the user, maybe translating it in an human readable format using i18n, and by the backend to create the ResourcePolicy to apply to the accessed item using and validating the additional inputs provided by the user where required.
+* If there is a *hasStartDate* attribute and it is true, the access condition to be applied requires to specify a startDate that must be less or equal than the value of the *maxStartDate* attribute (if null any date is acceptable)
+* If there is a *hasEndDate* attribute and it is true, the access condition to be applied requires to specify an endDate that must be less or equal than the value of the *maxEndDate* attribute (if null any date is acceptable). If a startDate is supplied the endDate must be greater than the startDate
+
+A null value for the accessConditionOptions attribute means that the access step doesn't allow the user to set a policy for the item. The item will get only the policies inherited from the collection.

--- a/submissionsection-types.md
+++ b/submissionsection-types.md
@@ -10,7 +10,6 @@ submission-form | [/config/submissionforms](submissionforms.md) | [example](work
 upload | [/config/submissionuploads](submissionuploads.md) | [example](workspaceitem-data-upload.md)
 license | [it is retrieved from the collection following the *license* link](collections.md#License) | [example](workspaceitem-data-license.md)
 cclicense | [/config/submissioncclicenses](submissioncclicenses.md) | [example](workspaceitem-data-cclicense.md)
-access | t.b.d | t.b.d
+access | [/config/submissionaccesses](submissionaccesses.md) | [example](workspaceitem-data-access.md)
 
 n/a --> not applicable. The sectionType doesn't require/support any extra configuration
-t.b.d. --> to be defined. We still need to discuss that

--- a/workspaceitem-data-access.md
+++ b/workspaceitem-data-access.md
@@ -1,0 +1,109 @@
+# WorkspaceItem data of access sectionType
+[Back to the definition of the workspaceitems endpoint](workspaceitems.md)
+
+The section data represent the data about the access condition
+
+```json
+{
+  "private": true,
+  "accessConditions": [
+    {
+      "id": 123,
+      "name": "openaccess"
+    },
+    {
+      "id": 126,
+      "name": "administrator"
+    },
+    {
+      "id": 127,
+      "name": "embargo",
+      "startDate": "2018-06-24T00:40:54.970+0000"
+    },
+    {
+      "id": 128,
+      "name": "lease",
+      "endDate": "2017-12-24T00:40:54.970+0000"
+    }
+  ]
+}
+```
+* private: indicates whether the current item should be private or not. For access configurations that do not allow the user to specify the visibility of the item, this value must be false.
+* accessConditions: an array of all the policies that has been applied by the user to the item. 
+
+## Patch operations
+The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
+
+Each successful Patch operation will return a HTTP 200 CODE with the new workspaceitem as body. See also the [General rules for the Patch operation](patch.md) for more details.
+
+### Add Access Condition
+To add an access condition the client must send a JSON Patch ADD operation as follow
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessConditions/-", "value": {name: "...", endDate: ".."}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+to **replace completely** the access conditions applied to a specific workspaceItem
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessCondition", "value": [{name: "...", endDate: ".."}]}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+The exact attributes that the access condition to add must have depend on the name attribute that will identify the access condition configuration as exposed by the [submissionaccesses configuration endpoint](submissionaccesses.md).
+For instance the following request is valid
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessConditions/-", "value": {name: "openaccess"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+instead the request
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessConditions/-", "value": {name: "embargo"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+will be rejected because a startDate attribute is also expected when an embargo is applied (according to the example configuration listed in this doc for the [submissionaccesses configuration endpoint](submissionaccesses.md). 
+
+The right request will be
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessConditions/-", "value": {name: "embargo", startDate: "2018-12-31"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+Please note that doesn't make sense to add an access condition in a specific index and, to simplify the client implementation it was assumed that the accessCondition array is never *null* but eventually an empty array so that you call always append new AccessCondition to the path "/sections/access /accessCondition/-".
+
+### Remove Access Condition
+To remove a previous applied access condition it is sufficient to invoke a remove operation on the accessCondition position path, i.e.
+
+`curl --data '{[ { "op": "remove", "path": "/sections/<:name-of-the-form>/accessConditions/<:access-idx>"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+the following request will reset the access condition to the empty array
+
+`curl --data '{[ { "op": "remove", "path": "/sections/<:name-of-the-form>/accessConditions"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+### Replace
+The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation without a previous value must return an error. See [general errors on PATCH requests](patch.md)
+
+#### Private
+To replace a previous private flag value it is sufficient to invoke a replace operation on the private position path, i.e.
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/private", "value": true|false }]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+For example, starting with the following eperson field data:
+```json
+ "private": true,
+```
+the replace operation `[{ "op": "replace", "path": "/sections/<:name-of-the-form>/private", "value": false]` will result in :
+```json
+  "private": false,
+```
+
+#### Access Condition
+You can replace an existent access condition with a new one or update some settings of an existent access condition using the replace operation. The new settings must be valid for the selected access condition (name) according to the [submissionaccesses configuration endpoint](submissionaccesses.md).
+
+To replace an access condition with a new one
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessConditions/0", "value": {name: "embargo", startDate: "2018-12-31"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+to update the embargo start date
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessConditions/0/startDate", "value": "2019-12-31"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+to transform an existent *openaccess* access condition to an *administrator* access condition
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/accessConditions/0/name", "value": "administrator"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+please note that the above works only because of openaccess and administrator have the same settings needs (no need of addition information). Indeed, the backend is expected to remove the existent policy and create a new policy. If the settings of the previous and new access condition differs the request must fail with a 422 error code
+
+## Relationship between the access conditions of the item and the bitstreams
+Access conditions set on an item can be overwritten by specific access conditions set directly on the bitstreams via [workspaceitem data upload](workspaceitem-data-upload.md). If a bistream has no specific access conditions then it inherits those of the item; if it does, then those of the item are ignored and are not applied to it.

--- a/workspaceitem-data-access.md
+++ b/workspaceitem-data-access.md
@@ -28,7 +28,7 @@ The section data represent the data about the access condition
   ]
 }
 ```
-* private: indicates whether the current item should be private or not. For access configurations that do not allow the user to specify the visibility of the item, this value must be false.
+* private: indicates whether the current item should be private or not.
 * accessConditions: an array of all the policies that has been applied by the user to the item. 
 
 ## Patch operations
@@ -87,6 +87,7 @@ the replace operation `[{ "op": "replace", "path": "/sections/<:name-of-the-form
 ```json
   "private": false,
 ```
+ For access configurations that do not allow the user to specify the visibility of the item, attempts to change the private flag result in a response with 422 status from the server.
 
 #### Access Condition
 You can replace an existent access condition with a new one or update some settings of an existent access condition using the replace operation. The new settings must be valid for the selected access condition (name) according to the [submissionaccesses configuration endpoint](submissionaccesses.md).
@@ -106,4 +107,4 @@ to transform an existent *openaccess* access condition to an *administrator* acc
 please note that the above works only because of openaccess and administrator have the same settings needs (no need of addition information). Indeed, the backend is expected to remove the existent policy and create a new policy. If the settings of the previous and new access condition differs the request must fail with a 422 error code
 
 ## Relationship between the access conditions of the item and the bitstreams
-Access conditions set on an item can be overwritten by specific access conditions set directly on the bitstreams via [workspaceitem data upload](workspaceitem-data-upload.md). If a bistream has no specific access conditions then it inherits those of the item; if it does, then those of the item are ignored and are not applied to it.
+Access conditions set on an item can be overwritten by specific access conditions set directly on the bitstreams via [workspaceitem data upload](workspaceitem-data-upload.md). If a bistream has no specific access conditions then it inherits those of the item; if an access conditions is inplace for the bitstream, then thos of the item are ignored and are not applied to it.


### PR DESCRIPTION
With this PR the contract for the Embargo item metadata is defined (https://github.com/DSpace/DSpace/issues/2839).
Both the endpoints related to the configuration and those related to the new section of the submission form are defined.