### PR TITLE
Add dataType property to browse index response

### DIFF
--- a/browses.md
+++ b/browses.md
@@ -14,7 +14,9 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api
 Provide detailed information about a specific browse index and access to the list of items and entries in the index. The JSON response document is as follow
 ```json
 {
+  "id": "title",
   "metadataBrowse": false,
+  "dataType": "title",
   "sortOptions": [
     {
       "name": "title",
@@ -37,7 +39,9 @@ Provide detailed information about a specific browse index and access to the lis
 } 
 ```
 
+* id: the identifier for the browse index
 * metadataBrowse: true if the browse index have two level, the 1st level shows the list of entries like author names, subjects, types, etc. the second level is the actual list of items linked to a specific entry
+* dataType: the kind of data indexed. Can have the values "title" for item titles, "date" for date fields or "text" for other metadata
 * sortOptions: the sort options available for this index
 * order: the default order applied to the index
 * metadata: the list of metadata used to build this index


### PR DESCRIPTION
### References
- Needed for https://github.com/DSpace/dspace-angular/issues/852

### Description
Adds a dataType property to the browse index response, in order to allow the UI to differentiate between the different types based on rest data alone.

The name "dataType" as well as the values "date", "title" and "text" have been chosen because they are already used in the configuration docs and in the api layer. DataType was simply never exposed on the REST endpoint.

I also added the "id" to the example response, as it was missing