### PR TITLE
Add 'typeBind' to submission form response example (#2873)

### DIFF
--- a/submissionforms.md
+++ b/submissionforms.md
@@ -4,7 +4,7 @@
 A submission-form represents a single data entry form, associated with a submission section. It is configurable, and consists of one or more data entry fields. In DSpace 6 and below, this concept was called an "input-form" and was configured via input-forms.xml.
 
 ## Main Endpoint
-**/api/config/submissionforms**   
+**/api/condu -h fig/submissionforms**   
 
 Provide access to the configured submission-forms. It returns the list of existent submission-forms.
 Please note that from DSpace 7 the submission-form concept has been introduced splitting the previous configuration file named input-forms.xml by page. Each submission-form describes a single page of inputs, combining different pages together is done with the [submission-definition](submissiondefinitions.md), aka the item-submission.xml configuration file 
@@ -38,7 +38,8 @@ Provide detailed information about a specific input-form. The JSON response docu
               "closed": null
             }
           ],
-          "languageCodes": []
+          "languageCodes": [],
+          "typeBind": []
         }
       ]
     },
@@ -113,7 +114,8 @@ Provide detailed information about a specific input-form. The JSON response docu
               "closed": null
             }
           ],
-          "languageCodes": []
+          "languageCodes": [],
+          "typeBind": []
         }
       ]
     },
@@ -135,7 +137,8 @@ Provide detailed information about a specific input-form. The JSON response docu
               "closed": false
             }
           ],
-          "languageCodes": []
+          "languageCodes": [],
+          "typeBind": []
         }
       ]
     },
@@ -152,7 +155,8 @@ Provide detailed information about a specific input-form. The JSON response docu
             "filter": "creativework.publisher:somepublishername",
             "searchConfiguration": "periodicalConfiguration",
             "externalSources": [ "sherpaJournal" ],
-            "nameVariants": false
+            "nameVariants": false,
+            "typeBind": ["Article"]
           }
         }
       ]


### PR DESCRIPTION
Related to [DS#2873 type-bind submission](https://github.com/DSpace/DSpace/issues/2873) 

Some simple examples are added to the REST API responses for the submission form configuration endpoint.

The related [A#806 dspace-angular ticket](https://github.com/DSpace/dspace-angular/issues/806) is still WIP while unit tests are finalised

This PR should be merged to the RestContract when the REST DS#2873 PR is merged to main.