### PR TITLE
Add some better Submission documentation to our RestContract

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository documents new DSpace REST API Contract beginning with version 7.
 ## REST Endpoints
 At the ROOT of the API a HAL document lists all the primary endpoints allowing full discovery of the API.
 * [Endpoints](endpoints.md) - Documentation for all available endpoints
+* [Submission / Deposit](submission.md) - How to deposit (or submit) a new Item into DSpace.
 * [Search Options and Relationships (on Endpoints)](search-rels.md) - How to use `/search` sub-paths on many endpoints
 * [Projections (on Endpoints)](projections.md) - How to use projections to return a subset or custom view of content
 * [CSRF Protection (on Endpoints)](csrf-tokens.md) - When using modifying verbs (POST, PUT, PATCH, DELETE), you *must* pass a CSRF token in the request.

--- a/submission.md
+++ b/submission.md
@@ -1,0 +1,68 @@
+# Submission / Deposit
+[REST Overview Documentation](README.md)
+
+One of the most used features in DSpace is the submission/workflow process.
+
+Because of its configurability, many different REST endpoints are used during this process.
+This page helps provide an overview of how to submit a new Item into DSpace.
+
+**NOTE: All the activities below require authentication and a valid CSRF token.**
+* Don't forget to include the "Authorization" header in every request! See [Authentication](authentication.md).
+* Don't forget to include the CSRF token in every request! See [CSRF Tokens](csrf-tokens.md).
+
+## Starting a Submission
+
+In DSpace, a submission is started by creating a WorkspaceItem. The WorkspaceItem acts as an "in progress" submission object.
+
+To create a WorkspaceItem, just `POST` to [/api/submission/workspaceitems](workspaceitem.md), passing in an owning Collection UUID (as every Item must belong to a Collection)
+```
+POST /api/submission/workspaceitems?owningCollection=<:collection-uuid>
+```
+This POST would create an empty WorkspaceItem by default.
+
+Alternatively, you can create a WorkspaceItem by uploading a file via a Multipart POST,
+or passing an [external entry value](external-authority-sources.md) whose metadata should be imported.
+For more information, see "Multipart POST Method" in the [/api/submission/workspaceitems](workspaceitem.md) documentation.
+
+## Modifying the Submission
+
+Once a submission is created (see above), the response will provide a new [/api/submission/workspaceitems](workspaceitem.md) resource.
+This is the WorkspaceItem object you created.
+
+It is **important** to keep the `id` of the WorkspaceItem, as this is necessary to update it or access it again.
+For example, using the `id`, you can load up the current state of your WorkspaceItem
+```
+GET /api/sumission/workspaceitems/<:id>
+```
+
+In the response, you'll see a list of `sections` which are available to complete for this WorkspaceItem.
+These `sections` correspond to [/api/config/submissionsections](submissionsections.md).
+Each section name is also its `id`, so you can use the section name to get more information via the
+that endpoint, e.g.
+```
+# Get info about the "traditionalpageone" section
+GET /api/config/submissionsections/traditionalpageone
+```
+The `sectionType` returned in the response will tell you the type of section. This is important
+in understanding how to interact with this section.
+
+Each `sectionType` is separately described below, including notes on how to edit the section
+* ["submission-form" section type](workspaceitem-data-metadata.md) - Used to enter metadata
+* ["upload" section type](workspaceitem-data-upload.md) - Used to upload files
+* ["access" section type](workspaceitem-data-access.md) - Used to edit access rights / embargo
+* ["license" section type](workspaceitem-data-license.md) - Used to sign off on the required license agreement
+* ["cclicense" section type](workspaceitem-data-cclicense.md) - Use to optionally apply a Creative Commons license
+
+## Completing the Submission / Starting Workflow
+
+In order to complete a submission, it MUST be sent into approval workflow. This is done by `POST`ing an existing
+WorkspaceItem to the WorkflowItem endpoint.
+
+See the "POST Method" of [/api/workflow/workflowitems](workflowitems.md) for examples.
+
+In DSpace, approval workflow is configured per Collection, and is not enabled by default.
+* If the Collection has no approval workflow configured (default), then the Item will become available immediately.
+The final Item's UUID will be the same as it was in the WorkspaceItem (i.e. the `uuid` returned via
+`/api/submission/workspaceitems/<:id>/item`)
+* If the Collection has an approval workflow configured, then a WorkflowItem will be returned. Its `id` can be used
+to access the WorkflowItem via `/api/workflow/workflowitems/<:id>`.

--- a/workflowitems.md
+++ b/workflowitems.md
@@ -2,14 +2,14 @@
 [Back to the list of all defined endpoints](endpoints.md)
 
 ## Main Endpoint
-**/api/submission/workflowitems**   
+**/api/workflow/workflowitems**
 
 Provide access to the workflowitems. It returns the list of existent workflowitems.
 
 Example: to be provided
 
 ## Single Workflow Item
-**/api/submission/workflowitems/<:id>**
+**/api/workflow/workflowitems/<:id>**
 
 Provide detailed information about a specific workflowitem. The JSON response document is as follow
 
@@ -142,19 +142,30 @@ It would respond with:
 * 204 if the workflow item doesn't exist
 
 ## POST Method
-To create a workflowitem, i.e. to start a workflow, a workspaceitem must be posted to the workflowitems resource collection endpoint (/api/submission/workflowitems).
-The workspaceitem must be supplied as URI in the request body using the text/uri-list content-type
-If succeed a 201 code will be returned and the new state of the workflowitem serialized in the body.
-If fails the following status code are expected
-403 Unauthorized - if the loggedin user is not the submitter of the workspaceitem
-422 Unprocessable Entity - if the workspace is not yet ready to be send through the workflow (i.e. there are validation errors)
+To create a WorkflowItem, i.e. to start a workflow, a WorkspaceItem must be posted to the `/workflowitems` resource
+collection endpoint (`/api/workflow/workflowitems`).
+The WorkspaceItem must be supplied as URI in the request body using the `text/uri-list` content-type.
+
+An example curl call:
+```
+ curl -i -X POST http://localhost:8080/server/api/workflow/workflowitems \
+ -H "Content-Type:text/uri-list" \
+ --data "https://localhost:8080/server/api/submission/workspaceitems/1234"
+```
+
+It would respond with:
+* 201 OK - If WorkflowItem was created successfully. The new state of the WorkflowItem is returned in the body.
+If the body is empty, this means that no workflow was enabled & the Item is immediately available in the system.
+* 401 Unauthorized - if you are not authenticated
+* 403 Unauthorized - if the loggedin user is not the submitter of the WorkspaceItem
+* 422 Unprocessable Entity - if the WorkspaceItem is not yet ready to be send through the workflow (i.e. there are validation errors)
 
 ## Multipart POST Method
 Multipart POST request will typically result in the creation of a new file in the section identified by the name of the variable used for the upload (uploads is the default name of the user uploaded content). The process will be managed by the implementation bind with the identified section.
 If succeed a 201 code will be returned and the new state of the workflowitem serialized in the body
 
 ## DELETE Method
-**DELETE /api/submission/workflowitems/<:id>**
+**DELETE /api/workflow/workflowitems/<:id>**
 
 Reset a workflow sending back the item to the workspace regardless to the step reached.
 


### PR DESCRIPTION
This PR added a new `submission.md` which provides a higher level overview of how to create, edit & complete a Submission.  

This can be used as a guide for others to better understand how to interact with our REST API to deposit content into DSpace, especially since you have to interact with a number of endpoints to complete a submission.

Also includes minor updates to WorkflowItem docs (see `workflowitems.md`) to update/correct the documentation based on the current behavior of this endpoint.