### PR TITLE
Clarify/enhance endpoint naming rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ We strive to align with these rules for all REST API endpoint names:
 * When compounds are used in an endpoint name, the words MUST be concatenated, all lowercase, without punctuation. For example: `metadatafields`, NOT `metadata-fields` or `MetadataFields` or `metadataFields`.
 * Endpoint names SHOULD be descriptive, but reasonably short (<25 characters). Abbreviations are _not recommended_, unless necessary for brevity. When abbreviations are used, the REST Contract MUST spell out the meaning of the abbreviation.
 * Endpoints SHOULD be grouped with other related endpoints by category or name. 
-    * The "category" is part of the endpoint's path. For example, all configuration-related endpoints use the category "config", which means they appear under `/api/config/*`.  Similarly, all submission-related endpoints use the category "submission", which means they appear under `/api/submission/*`.
+    * The "category" is the first part of the endpoint's path and is always a singular noun. For example, all configuration-related endpoints use the category "config", which means they appear under `/api/config/*`.  Similarly, all submission-related endpoints use the category "submission", which means they appear under `/api/submission/*`.
     * Alternatively, the name of the endpoint may include a prefix to relate it to other endpoints.  For example, all workflow related endpoints start with the prefix "workflow", regardless of their category. For example: `/api/config/workflowdefinitions`, `/api/config/workflowsteps`, `/api/workflow/workflowitems`.
 
 ### HATEOAS & HAL

--- a/README.md
+++ b/README.md
@@ -189,7 +189,15 @@ If the request parameters lead to a page outside the result set, then an empty p
 In the creation of the REST API, we've tried to follow a few specific design principles listed below
 
 ### On the Naming of Endpoints
-Names should be descriptive but reasonably short. Use nouns instead of verbs. Form compounds by concatenating words, all lower case, without punctuation.  For example: `metadatafields`, not `metadata-fields` or `MetadataFields`.
+
+We strive to align with these rules for all REST API endpoint names:
+* Endpoint names MUST use plural nouns instead of verbs.
+* When compounds are used in an endpoint name, the words MUST be concatenated, all lowercase, without punctuation. For example: `metadatafields`, NOT `metadata-fields` or `MetadataFields` or `metadataFields`.
+* Endpoint names SHOULD be descriptive, but reasonably short (<25 characters). Abbreviations are _not recommended_, unless necessary for brevity. When abbreviations are used, the REST Contract MUST spell out the meaning of the abbreviation.
+* Endpoints SHOULD be grouped with other related endpoints by category or name. 
+    * The "category" is part of the endpoint's path. For example, all configuration-related endpoints use the category "config", which means they appear under `/api/config/*`.  Similarly, all submission-related endpoints use the category "submission", which means they appear under `/api/submission/*`.
+    * Alternatively, the name of the endpoint may include a prefix to relate it to other endpoints.  For example, all workflow related endpoints start with the prefix "workflow", regardless of their category. For example: `/api/config/workflowdefintions`, `/api/config/workflowsteps`, `/api/workflow/workflowitems`.
+
 
 ### HATEOAS & HAL
 The REST API supports the [HATEOAS paradigm](https://restfulapi.net/hateoas/) and adopt the [HAL format](http://stateless.co/hal_specification.html) to express links and embedded resources. Links are always **absolute** to allow for easier implementation of "follow link" methods on the REST client side.

--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@ We strive to align with these rules for all REST API endpoint names:
 * Endpoint names SHOULD be descriptive, but reasonably short (<25 characters). Abbreviations are _not recommended_, unless necessary for brevity. When abbreviations are used, the REST Contract MUST spell out the meaning of the abbreviation.
 * Endpoints SHOULD be grouped with other related endpoints by category or name. 
     * The "category" is part of the endpoint's path. For example, all configuration-related endpoints use the category "config", which means they appear under `/api/config/*`.  Similarly, all submission-related endpoints use the category "submission", which means they appear under `/api/submission/*`.
-    * Alternatively, the name of the endpoint may include a prefix to relate it to other endpoints.  For example, all workflow related endpoints start with the prefix "workflow", regardless of their category. For example: `/api/config/workflowdefintions`, `/api/config/workflowsteps`, `/api/workflow/workflowitems`.
-
+    * Alternatively, the name of the endpoint may include a prefix to relate it to other endpoints.  For example, all workflow related endpoints start with the prefix "workflow", regardless of their category. For example: `/api/config/workflowdefinitions`, `/api/config/workflowsteps`, `/api/workflow/workflowitems`.
 
 ### HATEOAS & HAL
 The REST API supports the [HATEOAS paradigm](https://restfulapi.net/hateoas/) and adopt the [HAL format](http://stateless.co/hal_specification.html) to express links and embedded resources. Links are always **absolute** to allow for easier implementation of "follow link" methods on the REST client side.


### PR DESCRIPTION
This is based on the discussion that took place in today's (Sept 22, 2022) DevMtg and in #181 .

Mostly, this clarifies existing rules, but also enhances our rule regarding use of abbreviations and endpoint name length.

I'm moving this to the 7.5 board as it's not required for 7.4, but early reviews are welcome.