### PR TITLE
authentication.md: add note about XSRF cookie

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -21,10 +21,10 @@ Return codes
 Parameters must be sent in the body of a `x-www-form-urlencoded` request, i.e
 
 ```
-curl -v -X POST https://{dspace-server.url}/server/api/authn/login --data "user=dspacedemo%2Badmin%40gmail.com&password=dspace" -H "X-XSRF-TOKEN: {csrf-token}"
+curl -v -X POST https://{dspace-server.url}/server/api/authn/login --data "user=dspacedemo%2Badmin%40gmail.com&password=dspace" -H "X-XSRF-TOKEN: {csrf-token}" -b "DSPACE-XSRF-COOKIE={xsrf-cookie}"
 ```
 
-Please note that authentication requires passing a valid [CSRF token](csrf-tokens.md), previously obtained from the REST API. Also note that `curl` assumes `-H 'Content-Type: application/x-www-form-urlencoded'` for a POST request as default. 
+Please note that authentication requires passing a valid [CSRF token](csrf-tokens.md) header and cookie, previously obtained from the REST API. Also note that `curl` assumes `-H 'Content-Type: application/x-www-form-urlencoded'` for a POST request as default.
 
 This call will return a JWT (JSON Web Token) in the response in the Authorization header according to the [bearer scheme](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1). This token has to be used in subsequent calls to provide your authentication details. For example:
 


### PR DESCRIPTION
We need to provide the CSRF token as a header and as a cookie.

Closes #209

Note: these docs are also a bit messy and difficult to read. I had to stop myself from fixing spelling mistakes, formatting, and language. If I get time I'll submit something to improve them...