### PR TITLE
Browse by support for Controlled Vocabulary

### DIFF
--- a/browses.md
+++ b/browses.md
@@ -54,6 +54,39 @@ Error codes:
 
 **404** if the browse index doesn't exist
 
+## Hierarchical browse index 
+**/api/discover/browses/<:index-name>**
+
+Provide detailed information about a specific hierarchical browse index and access to the parameters required to access the list of items and entries. The JSON response document is as follows
+```json
+{
+  "id": "keyword",
+  "facetType": "subject",
+  "vocabulary": "srsc",
+  "type": "hierarchicalBrowse",
+  "metadata": [
+    "dc.subject"
+  ],
+  "_links" : {
+    "vocabulary" : {
+      "href" : "/server/api/submission/vocabularyEntryDetails/search/top?vocabulary=srsc"
+    }
+  }
+} 
+```
+
+* id: the identifier for the browse index
+* facetType: the discovery filter to use to filter the items
+* vocabulary: the name of the vocabulary containing the tree
+* metadata: the list of metadata used to build this index
+
+Exposed links:
+* vocabulary: link to the vocabulary containing the tree
+
+Error codes:
+
+**404** if the browse index doesn't exist
+
 ## Browse indexes configured for metadata linking
 ### Get a single index configured as browse links for the given metadata fields
 **/api/discover/browses/search/byFields?fields=<:field>**

--- a/browses.md
+++ b/browses.md
@@ -8,6 +8,29 @@ Provide access to the browse system (SOLR based). It returns the list of availab
 
 Example: <https://{dspace.server.url}/api/discover/browses>
 
+## Browse types
+
+There are currently types of browse, each behaving differently:
+* `valueList`:
+  * The browse index has two levels
+  * The 1st level shows the list of entries like author names, subjects, types, etc
+  * The second level is the actual list of items linked to a specific entry
+  * The `items` link is not used
+  * The `entries` link is used to render the author names, subjects, types, etc
+  * The `vocabulary` link is not used
+* `flatBrowse`:
+  * The browse index has one level: the full list of items
+  * The `items` link is used to render this list of items
+  * The `entries` link is not used
+  * The `vocabulary` link is not used
+* `hierarchicalBrowse`:
+  * The browse index displays the vocabulary tree
+  * The 1st level shows the tree
+  * The second level is the actual list of items linked to a specific entry
+  * The `items` link is not used
+  * The `entries` link is not used
+  * The `vocabulary` link is used to render the tree
+
 ## Single browse index 
 **/api/discover/browses/<:index-name>**
 

--- a/browses.md
+++ b/browses.md
@@ -15,6 +15,7 @@ Provide detailed information about a specific browse index and access to the lis
 ```json
 {
   "id": "title",
+  "browseType": "flatBrowse",
   "metadataBrowse": false,
   "dataType": "title",
   "sortOptions": [
@@ -40,6 +41,9 @@ Provide detailed information about a specific browse index and access to the lis
 ```
 
 * id: the identifier for the browse index
+* browseType:
+  * `valueList` if the browse index has two levels, the 1st level shows the list of entries like author names, subjects, types, etc. the second level is the actual list of items linked to a specific entry
+  * `flatBrowse` if the browse index has one level: the full list of items
 * metadataBrowse: true if the browse index have two level, the 1st level shows the list of entries like author names, subjects, types, etc. the second level is the actual list of items linked to a specific entry
 * dataType: the kind of data indexed. Can have the values "title" for item titles, "date" for date fields or "text" for other metadata
 * sortOptions: the sort options available for this index
@@ -61,21 +65,23 @@ Provide detailed information about a specific hierarchical browse index and acce
 ```json
 {
   "id": "keyword",
+  "browseType": "hierarchicalBrowse",
   "facetType": "subject",
   "vocabulary": "srsc",
-  "type": "hierarchicalBrowse",
+  "type": "browse",
   "metadata": [
     "dc.subject"
   ],
   "_links" : {
     "vocabulary" : {
-      "href" : "/server/api/submission/vocabularyEntryDetails/search/top?vocabulary=srsc"
+      "href" : "/server/api/submission/vocabularies/srsc"
     }
   }
 } 
 ```
 
 * id: the identifier for the browse index
+* browseType: `hierarchicalBrowse` if the browse index should display the vocabulary tree. The 1st level shows the tree. The second level is the actual list of items linked to a specific entry
 * facetType: the discovery filter to use to filter the items
 * vocabulary: the name of the vocabulary containing the tree
 * metadata: the list of metadata used to build this index


### PR DESCRIPTION
This PR adds compatibility for controlled vocabularies in the browse pages.

It includes a link to the browse vocabulary to display the tree, and the name of the facet to filter the items