### PR TITLE
(NEEDS DISCUSSION) Contract for isMemberOf and isSubGroupOf searches off `/api/eperson/groups`

### DIFF
--- a/epersongroups.md
+++ b/epersongroups.md
@@ -327,13 +327,39 @@ Return codes:
 * 404 Not found - if the parent group doesn't exist
 * 422 Unprocessable Entity - if the child group doesn't exist or if the specified eperson doesn't exist
 
-## Search
+## Search Groups by Metadata
 **GET /api/eperson/groups/search/byMetadata?query=<:name>**
 
 This supports a basic search in the metadata.
 It will search in:
 * UUID (exact match)
 * group name
+
+## Search Groups by Membership
+**GET /api/eperson/groups/search/isMemberOf?group=<:name>**
+
+Determines whether the currently logged in user is a direct member of the Group specified by `group`.
+
+The `group` param only supports two possible values:
+* UUID (exact match)
+* Group Name (exact match, as Group names are unique)
+
+If the currently logged in user is a member of the Group, then a `200 OK` will be returned with one result (totalElements=1) in the response. That one result will be the matched group.
+
+If the currently logged in user is NOT a member of the Group (or the `group` param matches no Groups), then a `200 OK` will be returned with zero results (totalElements=0).
+
+## Search Groups by SubGroups
+**GET /api/eperson/groups/search/isSubGroupOf?group=<:name>&subgroup=<:name>**
+
+Determines whether the given `subgroup` is a direct member of the Group specified by `group`.
+
+The `subgroup` and `group` params only supports possible values:
+* UUID (exact match)
+* Group Name (exact match, as Group names are unique)
+
+If the subgroup is a member of the Group, then a `200 OK` will be returned with one result (totalElements=1) in the response. That one result will be the parent Group.
+
+If the subgroup is NOT a member of the Group (or the `group` param matches no Groups), then a `200 OK` will be returned with zero results (totalElements=0).
 
 ## Related DSpace Object of group
 **GET /api/eperson/groups/<:uuid>/object** (READ-ONLY)


### PR DESCRIPTION
Related to https://github.com/DSpace/DSpace/issues/9052

While investigating performance problems described in https://github.com/DSpace/DSpace/issues/9052, I've realized that our Angular UI includes code which requests *every EPerson in a Group* or *every Subgroup in a Group* in order to determine whether a given EPerson or Group is already included in a given parent Group.

For example:
* `isMemberOfGroup` in `members-list.component.ts`: https://github.com/DSpace/dspace-angular/blob/main/src/app/access-control/group-registry/group-form/members-list/members-list.component.ts#L216C1-L233C3
* `isSubgroupOfGroup` in `subgroups-list.component.ts`: https://github.com/DSpace/dspace-angular/blob/main/src/app/access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts#L138-L159

This UI behavior will cause performance issues when a Group has a large number of members (either EPerson or Subgroup). 
These queries will have much better performance if moved to the backend via `isMemberOf` and `isSubGroupOf` endpoints.

Therefore, **this PR suggestions two new REST API endpoints** (to replace the above UI methods):
1. `GET /api/eperson/groups/search/isMemberOf?group=<:name>`
    * Implementation would likely use a slightly updated version of the `GroupService.isMember()` method: https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java#L311-L313
    * Strangely, we already have (unused) code in dspace-angular which attempts to use this `/search/isMemberOf` endpoint. https://github.com/DSpace/dspace-angular/blob/main/src/app/core/eperson/group-data.service.ts#L114-L124
2. `GET /api/eperson/groups/search/isSubGroupOf?group=<:name>&subgroup=<:name>`
    * Implementation would likely use a new `GroupService.isMemberGroup()` method, modeled similar to `isMember()` above.


Because this is a performance fix & is backwards compatible, I'd recommend we consider this change for 7.6.1.   The code to implement these endpoints would be rather simple (see implementation notes above)