### PR TITLE
Replace references to api7.dspace.org

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -12,7 +12,7 @@ This endpoint only accepts the `POST` method. Parameters and body structure depe
 
 A `WWW-Authenticate` header is returned listing the different authentication method supported by the system.
 Below an example listing the password and shibboleth authentication:  
-`WWW-Authenticate: shibboleth realm="DSpace REST API", location="https://api7.dspace.org/Shibboleth.sso/Login?target=https%3A%2F%2Fapi7.dspace.org", password realm="DSpace REST API"`
+`WWW-Authenticate: shibboleth realm="DSpace REST API", location="https://demo.dspace.org/Shibboleth.sso/Login?target=https%3A%2F%2Fdemo.dspace.org", password realm="DSpace REST API"`
 
 Return codes
 - 200 Ok. If the authentication succeed. The JWT will be returned in the response Header Authorization. 

--- a/bitstreamformats.md
+++ b/bitstreamformats.md
@@ -6,7 +6,7 @@
 
 Provide access to the bitstream formats defined in the registry (DBMS based). It returns the list of existent metadata fields.
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/bitstreamformats>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/bitstreamformats>
 
 **POST /api/core/bitstreamformats**   
 

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -41,7 +41,7 @@ Bitstream metadata can be modified as described in [Modifying metadata via Patch
 ### Format
 **GET /api/core/bitstreams/<:uuid>/format**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/format>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/format>
 
 It returns the format of the bitstream
 
@@ -51,7 +51,7 @@ Update the bitstream format of the bitstream
 
 Sample CURL command:
 ```
-curl -i -X PUT 'https://api7.dspace.org/server/api/core/bitstreams/6ba01288-8a5a-4acf-96f1-fd0730424a1f/format' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/core/bitstreamformats/6'
+curl -i -X PUT 'https://demo.dspace.org/server/api/core/bitstreams/6ba01288-8a5a-4acf-96f1-fd0730424a1f/format' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/core/bitstreamformats/6'
 ```
 
 The uri-list should always contain exactly 1 bitstream format. This bitstream format will be assigned to the bitstream
@@ -73,7 +73,7 @@ Keep in mind that there's a change to dc.format in the API related to bitstream 
 ### Bundle
 **GET /api/core/bitstreams/<:uuid>/bundle**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/bundle>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/bundle>
 
 It returns the bundle of the bitstream
 
@@ -83,7 +83,7 @@ Move the bitstream to another bundle
 
 Sample CURL command:
 ```
-curl -i -X PUT 'https://api7.dspace.org/server/api/core/bitstreams/6ba01288-8a5a-4acf-96f1-fd0730424a1f/bundle' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/core/bundles/0b3c0ebf-83bc-4017-afa1-9df37a1a065c'
+curl -i -X PUT 'https://demo.dspace.org/server/api/core/bitstreams/6ba01288-8a5a-4acf-96f1-fd0730424a1f/bundle' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/core/bundles/0b3c0ebf-83bc-4017-afa1-9df37a1a065c'
 ```
 
 The uri-list should always contain exactly 1 bitstream format. This bitstream format will be assigned to the bitstream
@@ -98,7 +98,7 @@ Error codes:
 ### Content
 **/api/core/bitstreams/<:uuid>/content**
 
-Example: <https://api7.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/content>
+Example: <https://demo.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/content>
 
 It returns the actual content (bits) described by the bitstream
 

--- a/browses.md
+++ b/browses.md
@@ -151,7 +151,7 @@ It returns a collection of BrowseEntryResource the JSON document looks like
         "count": 1,
         "_links": {
           "items": {
-            "href": "https://api7.dspace.org/server/api/discover/browses/author/items?filterValue=Arulmozhiyal, Ramaswamy"
+            "href": "https://demo.dspace.org/server/api/discover/browses/author/items?filterValue=Arulmozhiyal, Ramaswamy"
           }
         }
       },

--- a/bundles.md
+++ b/bundles.md
@@ -29,16 +29,16 @@ Provide detailed information about a specific bundle. A sample JSON response doc
   "type": "bundle",
   "_links" : {
     "primarybitstream" : {
-      "href" : "https://api7.dspace.org/server/api/core/bitstreams/ac49f361-4ffd-47a4-8eb2-e6c73c3f3e76"
+      "href" : "https://demo.dspace.org/server/api/core/bitstreams/ac49f361-4ffd-47a4-8eb2-e6c73c3f3e76"
     },
     "bitstreams" : {
-      "href" : "https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams"
+      "href" : "https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams"
     },
     "item" : {
-      "href" : "https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/item"
+      "href" : "https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/item"
     },
     "self" : {
-      "href" : "https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb"
+      "href" : "https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb"
     }
   },
    "_embedded" : {
@@ -79,13 +79,13 @@ Provide detailed information about a specific bundle. A sample JSON response doc
         "type" : "bitstream",
         "_links" : {
           "content" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14/content"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14/content"
           },
           "format" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14/format"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14/format"
           },
           "self" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14"
           }
         }
       }, {
@@ -125,13 +125,13 @@ Provide detailed information about a specific bundle. A sample JSON response doc
         "type" : "bitstream",
         "_links" : {
           "content" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc/content"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc/content"
           },
           "format" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc/format"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc/format"
           },
           "self" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc"
           }
         }
       }
@@ -157,7 +157,7 @@ Deleting a bundle will delete all bitstreams in the bundle
 
 **GET /api/core/bundles/<:uuid>/bitstreams**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams>
 
 It returns the bitstreams within this bundle. See the [bitstream endpoint](bitstreams.md#Single-Bitstream) for more info
 
@@ -168,11 +168,11 @@ The supported parameters are:
 
 TODO: the item has to be known as well when creating a new bitstream. See https://jira.duraspace.org/browse/DS-4317?focusedCommentId=63099&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-63099
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams>
 
 Curl example:
 ```
-curl 'https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams' \
+curl 'https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams' \
  -XPOST -H 'Content-Type: multipart/form-data' \
  -H 'Authorization: Bearer eyJhbGciOiJI...' \
  -F "file=@Downloads/test.html" \
@@ -231,7 +231,7 @@ Current list of bitstreams:
         "uuid" : "1ce6db0e-662f-4a13-ba87-c371ad664b14",
         "_links" : {
           "self" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14"
           }
         }
       }, {
@@ -239,7 +239,7 @@ Current list of bitstreams:
         "uuid" : "4dd9621f-a464-4192-bc17-d70f68845bdc",
         "_links" : {
           "self" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc"
           }
         }
       }
@@ -269,7 +269,7 @@ New list of bitstreams:
         "uuid" : "4dd9621f-a464-4192-bc17-d70f68845bdc",
         "_links" : {
           "self" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/4dd9621f-a464-4192-bc17-d70f68845bdc"
           }
         }
       },
@@ -278,7 +278,7 @@ New list of bitstreams:
         "uuid" : "1ce6db0e-662f-4a13-ba87-c371ad664b14",
         "_links" : {
           "self" : {
-            "href" : "https://api7.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14"
+            "href" : "https://demo.dspace.org/server/api/core/bitstreams/1ce6db0e-662f-4a13-ba87-c371ad664b14"
           }
         }
       }

--- a/claimedtasks.md
+++ b/claimedtasks.md
@@ -95,9 +95,9 @@ If successful a 201 code will be returned along with the new claimedtask. The po
 
 An example curl call:
 ```
-curl -i -X POST https://api7.dspace.org/server/api/workflow/claimedtasks
+curl -i -X POST https://demo.dspace.org/server/api/workflow/claimedtasks
 \ -H "Content-Type:text/uri-list" \
---data "https://api7.dspace.org/server/api/workflow/pooltasks/1"
+--data "https://demo.dspace.org/server/api/workflow/pooltasks/1"
 ```
 
 Return codes:

--- a/collections.md
+++ b/collections.md
@@ -6,7 +6,7 @@
 
 Provide access to the list of collections (DBMS based).
 
-Example: <https://api7.dspace.org/server/#/server/api/core/collections>
+Example: <https://demo.dspace.org/server/#/server/api/core/collections>
 
 ## Single Collection
 **/api/core/collections/<:uuid>**
@@ -196,7 +196,7 @@ Collection metadata can be modified as described in [Modifying metadata via Patc
 #### Retrieve Logo
 **GET /api/core/collections/<:uuid>/logo**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo>
 
 It returns the bitstream representing the logo of this collection. [See the bitstream endpoint for more info](bitstreams.md#Single Bitstream)
 
@@ -207,7 +207,7 @@ To be used on a collection without a logo
 
 Curl example:
 ```
-curl 'https://api7.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+curl 'https://demo.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
  -XPOST -H 'Content-Type: multipart/form-data' \
  -H 'Authorization: Bearer eyJhbGciOiJI...' \
  -F "file=@Downloads/test.png"
@@ -259,7 +259,7 @@ Return information about the license template in use by the collection. The json
 #### Retrieve Item template
 **GET /api/core/collections/<:uuid>/itemtemplate**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/itemtemplate>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/itemtemplate>
 
 It returns the item representing the item template of this collection. [See the item endpoint for more info](items.md#Single Item)
 
@@ -329,7 +329,7 @@ The json representation is as follow
         "type": "resourcePolicy",
         "_links": {
           "self": {
-            "href": "https://api7.dspace.org/server/api/authz/resourcePolicies/2844"
+            "href": "https://demo.dspace.org/server/api/authz/resourcePolicies/2844"
           }
         }
       }
@@ -337,7 +337,7 @@ The json representation is as follow
   },
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/collections/5ad50035-ca22-4a4d-84ca-d5132f34f588/defaultAccessConditions"
+      "href": "https://demo.dspace.org/server/api/core/collections/5ad50035-ca22-4a4d-84ca-d5132f34f588/defaultAccessConditions"
     }
   },
   "page": {
@@ -393,7 +393,7 @@ A sample json response:
   "last_harvested": null,
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvester"
+      "href": "https://demo.dspace.org/server/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvester"
     }
   },
   "_embedded": {
@@ -417,7 +417,7 @@ A sample json response:
       ],
       "_links": {
         "self": {
-          "href": "https://api7.dspace.org/server/api/config/harvestermetadata"
+          "href": "https://demo.dspace.org/server/api/config/harvestermetadata"
         }
       }
     }
@@ -440,7 +440,7 @@ A sample json response if no harvesting is enabled:
   "last_harvested": null,
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvester"
+      "href": "https://demo.dspace.org/server/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvester"
     }
   },
   "_embedded": {
@@ -464,7 +464,7 @@ A sample json response if no harvesting is enabled:
       ],
       "_links": {
         "self": {
-          "href": "https://api7.dspace.org/server/api/config/harvestermetadata"
+          "href": "https://demo.dspace.org/server/api/config/harvestermetadata"
         }
       }
     }

--- a/communities.md
+++ b/communities.md
@@ -6,7 +6,7 @@
 
 Provide access to the communities (DBMS based). It returns the list of existent communities.
 
-Example: <https://api7.dspace.org/server/#/server/api/core/communities>
+Example: <https://demo.dspace.org/server/#/server/api/core/communities>
 
 ## Single Community 
 **/api/core/communities/<:uuid>**
@@ -97,7 +97,7 @@ The supported parameters are:
 ### Collections
 **/api/core/communities/<:uuid>/collections**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/communities/7669c72a-3f2a-451f-a3b9-9210e7a4c02f/collections>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/communities/7669c72a-3f2a-451f-a3b9-9210e7a4c02f/collections>
 
 It returns the collections within this community
 
@@ -108,7 +108,7 @@ The supported parameters are:
 #### Retrieve Logo
 **GET /api/core/communities/<:uuid>/logo**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/communities/7669c72a-3f2a-451f-a3b9-9210e7a4c02f/logo>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/communities/7669c72a-3f2a-451f-a3b9-9210e7a4c02f/logo>
 
 It returns the bitstream representing the logo of this community. [See the bitstream endpoint for more info](bitstreams.md#Single Bitstream)
 
@@ -119,7 +119,7 @@ To be used on a community without a logo
 
 Curl example:
 ```
-curl 'https://api7.dspace.org/server/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+curl 'https://demo.dspace.org/server/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
  -XPOST -H 'Content-Type: multipart/form-data' \
  -H 'Authorization: Bearer eyJhbGciOiJI...' \
  -F "file=@Downloads/test.png"
@@ -149,7 +149,7 @@ To be used on a community with a logo
 
 Curl example:
 ```
-curl 'https://api7.dspace.org/server/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+curl 'https://demo.dspace.org/server/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
  -XPUT -H 'Content-Type: multipart/form-data' \
  -H 'Authorization: Bearer eyJhbGciOiJI...' \
  -F "file=@Downloads/test.png"
@@ -179,7 +179,7 @@ To be used on a community with a logo
 
 Curl example:
 ```
-curl 'https://api7.dspace.org/server/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+curl 'https://demo.dspace.org/server/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
  -XDELETE \
  -H 'Authorization: Bearer eyJhbGciOiJI...'
 ```

--- a/entitytypes.md
+++ b/entitytypes.md
@@ -8,7 +8,7 @@ Entities are Items with a valid value in the `dspace.entity.type`
 ## Main Endpoint
 **/api/core/entitytypes**
 
-A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/entitytypes
+A sample can be found at https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/entitytypes
 
 ```json
 {
@@ -20,10 +20,10 @@ A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org
         "type": "entitytype",
         "_links": {
           "self": {
-            "href": "https://api7.dspace.org/server/api/core/entitytypes/1"
+            "href": "https://demo.dspace.org/server/api/core/entitytypes/1"
           },
           "relationshiptypes": {
-            "href": "https://api7.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
+            "href": "https://demo.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
           }
         }
       },
@@ -33,10 +33,10 @@ A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org
         "type": "entitytype",
         "_links": {
           "self": {
-            "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+            "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
           },
           "relationshiptypes": {
-            "href": "https://api7.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
+            "href": "https://demo.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
           }
         }
       }
@@ -44,7 +44,7 @@ A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org
   },
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/entitytypes"
+      "href": "https://demo.dspace.org/server/api/core/entitytypes"
     }
   },
   "page": {
@@ -59,7 +59,7 @@ A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org
 ## Single Entity Type
 **/api/core/entitytypes/<:id>**
 
-A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/entitytypes/1
+A sample can be found at https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/entitytypes/1
 
 ```json
 {
@@ -68,10 +68,10 @@ A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org
   "type": "entitytype",
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/entitytypes/1"
+      "href": "https://demo.dspace.org/server/api/core/entitytypes/1"
     },
     "relationshiptypes": {
-      "href": "https://api7.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
+      "href": "https://demo.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
     }
   }
 }
@@ -82,13 +82,13 @@ It contains a HAL link to the Relationship Types for the current Entity Type (no
 ## Relationship Types for the current Entity Type
 **/api/core/entitytypes/<:id>/relationshiptypes**
 
-A sample can be found at https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/entitytypes/1/relationshiptypes
+A sample can be found at https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/entitytypes/1/relationshiptypes
 It embeds the [relationshiptypes](relationshiptypes.md) which are linked to the given entity type (either on the left or right side)
 
 ## Get Entity type from label
 **/api/core/entitytypes/label/<:entity-type-label>**
 
-A sample request would be https://api7.dspace.org/server/#/server/api/core/entitytypes/label/Person
+A sample request would be https://demo.dspace.org/server/#/server/api/core/entitytypes/label/Person
 The entity-type-label is mandatory
 
 There's always at most one entity type per label.

--- a/epersongroups.md
+++ b/epersongroups.md
@@ -19,13 +19,13 @@
   "type": "group",
   "_links": {
     "subgroups": {
-      "href": "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups"
+      "href": "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups"
     },
     "epersons": {
-      "href": "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons"
+      "href": "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons"
     },
     "self": {
-      "href": "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc"
+      "href": "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc"
     }
   }
 }
@@ -122,13 +122,13 @@ Sample:
           "type": "group",
           "_links": {
             "subgroups": {
-              "href": "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups"
+              "href": "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups"
             },
             "epersons": {
-              "href": "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons"
+              "href": "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons"
             },
             "self": {
-              "href": "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc"
+              "href": "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc"
             }
           }
         }
@@ -136,7 +136,7 @@ Sample:
     },
     "_links": {
       "self": {
-        "href": "https://api7.dspace.org/server/api/eperson/groups/3b1de75d-5bf9-4ca3-bf4d-42bc8abd0d42/subgroups"
+        "href": "https://demo.dspace.org/server/api/eperson/groups/3b1de75d-5bf9-4ca3-bf4d-42bc8abd0d42/subgroups"
       }
     },
     "page": {
@@ -162,9 +162,9 @@ The actual sub group is part of the body using the uri-list
 
 Example:
 ```bash
-curl -i -X POST "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups"
+curl -i -X POST "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups"
   -H "Content-Type:text/uri-list"
-  -d "https://api7.dspace.org/server/api/eperson/groups/05e3dbb8-332b-4487-a3f9-d78431b6cc02"
+  -d "https://demo.dspace.org/server/api/eperson/groups/05e3dbb8-332b-4487-a3f9-d78431b6cc02"
 ```
 
 The group is mandatory
@@ -184,7 +184,7 @@ A DELETE request will result in removing a subgroup from the parent group
 Example:
 ```bash
 curl -i -X DELETE 
-  "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups/05e3dbb8-332b-4487-a3f9-d78431b6cc02"
+  "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/subgroups/05e3dbb8-332b-4487-a3f9-d78431b6cc02"
 ```
 
 The above request would remove the mapping between the parent group with UUID `617cf46b-535c-42d5-9d22-327ce2eff6dc`
@@ -258,7 +258,7 @@ Sample:
           "type": "eperson",
           "_links": {
             "self": {
-              "href": "https://api7.dspace.org/server/api/eperson/epersons/a6086b34-3918-45b7-8ddd-9329a702a26a"
+              "href": "https://demo.dspace.org/server/api/eperson/epersons/a6086b34-3918-45b7-8ddd-9329a702a26a"
             }
           }
         }
@@ -266,7 +266,7 @@ Sample:
     },
     "_links": {
       "self": {
-        "href": "https://api7.dspace.org/server/api/eperson/groups/3b1de75d-5bf9-4ca3-bf4d-42bc8abd0d42/epersons"
+        "href": "https://demo.dspace.org/server/api/eperson/groups/3b1de75d-5bf9-4ca3-bf4d-42bc8abd0d42/epersons"
       }
     },
     "page": {
@@ -292,9 +292,9 @@ The actual eperson is part of the body using the uri-list
 
 Example:
 ```bash
-curl -i -X POST "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons"
+curl -i -X POST "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons"
   -H "Content-Type:text/uri-list"
-  -d "https://api7.dspace.org/server/api/eperson/epersons/a6086b34-3918-45b7-8ddd-9329a702a26a"
+  -d "https://demo.dspace.org/server/api/eperson/epersons/a6086b34-3918-45b7-8ddd-9329a702a26a"
 ```
 
 The eperson is mandatory
@@ -313,7 +313,7 @@ To remove an eperson from a parent group, perform a DELETE to the Epeople of a G
 Example:
 ```bash
 curl -i -X DELETE 
-  "https://api7.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons/a6086b34-3918-45b7-8ddd-9329a702a26a"
+  "https://demo.dspace.org/server/api/eperson/groups/617cf46b-535c-42d5-9d22-327ce2eff6dc/epersons/a6086b34-3918-45b7-8ddd-9329a702a26a"
 ```
 
 The above request would remove the mapping between the group with UUID `617cf46b-535c-42d5-9d22-327ce2eff6dc`

--- a/epersons.md
+++ b/epersons.md
@@ -51,10 +51,10 @@
   "type": "eperson",
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/eperson/epersons/028dcbb8-0da2-4122-a0ea-254be49ca107"
+      "href": "https://demo.dspace.org/server/api/eperson/epersons/028dcbb8-0da2-4122-a0ea-254be49ca107"
     },
     "groups": {
-      "href": "https://api7.dspace.org/server/api/eperson/epersons/028dcbb8-0da2-4122-a0ea-254be49ca107/groups"
+      "href": "https://demo.dspace.org/server/api/eperson/epersons/028dcbb8-0da2-4122-a0ea-254be49ca107/groups"
     }
   }
 }

--- a/external-authority-sources.md
+++ b/external-authority-sources.md
@@ -18,13 +18,13 @@ Example:
         "type": "externalsource",
         "_links": {
           "entries": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid/entries"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid/entries"
           },
           "entityTypes": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid/entityTypes"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid/entityTypes"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid"
           }
         }
       },
@@ -35,13 +35,13 @@ Example:
         "type": "externalsource",
         "_links": {
           "entries": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/ciencia/entries"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/ciencia/entries"
           },
           "entityTypes": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/ciencia/entityTypes"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/ciencia/entityTypes"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/ciencia"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/ciencia"
           }
         }
       },
@@ -52,13 +52,13 @@ Example:
         "type": "externalsource",
         "_links": {
           "entries": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/my_staff_db/entries"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/my_staff_db/entries"
           },
           "entityTypes": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/my_staff_db/entityTypes"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/my_staff_db/entityTypes"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/my_staff_db"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/my_staff_db"
           }
         }
       }
@@ -66,7 +66,7 @@ Example:
   },
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/integration/externalsources"
+      "href": "https://demo.dspace.org/server/api/integration/externalsources"
     }
   },
   "page": {
@@ -158,13 +158,13 @@ sample for an external source /server/api/integration/externalsources/orcid/entr
         "type": "externalSourceEntry",
         "_links": {
           "authority": {
-            "href": "https://api7.dspace.org/server/api/integration/authorities/authors/entryValues/d4b5ca88-9d6d-4a87-b905-fef0f8cae26c"
+            "href": "https://demo.dspace.org/server/api/integration/authorities/authors/entryValues/d4b5ca88-9d6d-4a87-b905-fef0f8cae26c"
           },
           "parent": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
           }
         }
       },
@@ -213,13 +213,13 @@ sample for an external source /server/api/integration/externalsources/orcid/entr
         "type": "externalSourceEntry",
         "_links": {
           "entity": {
-            "href": "https://api7.dspace.org/server/api/core/item/6fd90bf5-b84f-47b3-aaec-a55bde3a2a5a"
+            "href": "https://demo.dspace.org/server/api/core/item/6fd90bf5-b84f-47b3-aaec-a55bde3a2a5a"
           },
           "parent": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid"
           },          
           "self": {
-            "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0003-3681-2038"
+            "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0003-3681-2038"
           }
         }
       }
@@ -281,13 +281,13 @@ sample for an external source /api/integration/externalsources/orcid/entryValues
   },
   "_links": {
     "entity": {
-      "href": "https://api7.dspace.org/server/api/core/item/00167e74-c027-4984-8564-85c3fe513d45"
+      "href": "https://demo.dspace.org/server/api/core/item/00167e74-c027-4984-8564-85c3fe513d45"
     },
     "parent": {
-      "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid"
+      "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid"
     },    
     "self": {
-      "href": "https://api7.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
+      "href": "https://demo.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
     }
   }
 }

--- a/harvestermetadata.md
+++ b/harvestermetadata.md
@@ -6,7 +6,7 @@
 
 Provide access to the list of harvesting metadata configurations (config based).
 
-Example: <https://api7.dspace.org/server/#/server/api/config/harvestermetadata>
+Example: <https://demo.dspace.org/server/#/server/api/config/harvestermetadata>
 
 
 A sample json response:
@@ -32,7 +32,7 @@ A sample json response:
   ],
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/config/harvestermetadata"
+      "href": "https://demo.dspace.org/server/api/config/harvestermetadata"
     }
   }
 }

--- a/item-requests.md
+++ b/item-requests.md
@@ -31,13 +31,13 @@ Provide detailed information about a specific request. The JSON response documen
   "requestName":"John Smith",
   "_links":{
     "bitstream":{
-      "href":"https://api7.dspace.org/server/api/tools/itemrequests/1/bitstream"
+      "href":"https://demo.dspace.org/server/api/tools/itemrequests/1/bitstream"
     },
     "item":{
-      "href":"https://api7.dspace.org/server/api/tools/itemrequests/1/item"
+      "href":"https://demo.dspace.org/server/api/tools/itemrequests/1/item"
     },
     "self":{
-      "href":"https://api7.dspace.org/server/api/tools/itemrequests/1"
+      "href":"https://demo.dspace.org/server/api/tools/itemrequests/1"
     }
   }
 }

--- a/items.md
+++ b/items.md
@@ -8,7 +8,7 @@ Provide access to the items (DBMS based). This endpoint is reserved to the admin
 
 Currently, this endpoint only returns "archived" items which are NOT withdrawn. However, withdrawn items and Workspace/Workflow items are findable via [search endpoints](search-endpoint.md). Template items are findable via the corresponding collection. In the future, this endpoint is likely to be updated to include all items, regardless of status, see https://github.com/DSpace/DSpace/issues/3325
 
-Example: <https://api7.dspace.org/server/#/server/api/core/items>
+Example: <https://demo.dspace.org/server/#/server/api/core/items>
 
 ## Single Item
 **/api/core/items/<:uuid>**
@@ -171,9 +171,9 @@ The URI-list should contain the [external entry value](external-authority-source
 
 An example curl call:
 ```
- curl -i -X POST https://api7.dspace.org/server/api/core/items?owningCollection=1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \
+ curl -i -X POST https://demo.dspace.org/server/api/core/items?owningCollection=1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \
  -H "Content-Type:text/uri-list" \
- --data "https://api7.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
+ --data "https://demo.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
 ```
 
 Only one external entry value should be present. If multiple external entry values are present, a 400 bad request will be thrown
@@ -335,7 +335,7 @@ Return code
 
 **GET /api/core/items/<:uuid>/bundles**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/bundles>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/bundles>
 
 It returns the bundles within this item. See the [bundle endpoint](bundles.md) for more info
 
@@ -350,13 +350,13 @@ It returns the bundles within this item. See the [bundle endpoint](bundles.md) f
     "type": "bundle",
     "_links" : {
       "primarybitstream" : {
-        "href" : "https://api7.dspace.org/server/api/core/bitstreams/ac49f361-4ffd-47a4-8eb2-e6c73c3f3e76"
+        "href" : "https://demo.dspace.org/server/api/core/bitstreams/ac49f361-4ffd-47a4-8eb2-e6c73c3f3e76"
       },
       "bitstreams" : {
-        "href" : "https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams"
+        "href" : "https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams"
       },
       "self" : {
-        "href" : "https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb"
+        "href" : "https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb"
       }
     }
   },
@@ -368,13 +368,13 @@ It returns the bundles within this item. See the [bundle endpoint](bundles.md) f
     "type": "bundle",
     "_links" : {
       "primarybitstream" : {
-        "href" : "https://api7.dspace.org/server/api/core/bitstreams/ac49f361-4ffd-47a4-8eb2-e6c73c3f3e76"
+        "href" : "https://demo.dspace.org/server/api/core/bitstreams/ac49f361-4ffd-47a4-8eb2-e6c73c3f3e76"
       },
       "bitstreams" : {
-        "href" : "https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams"
+        "href" : "https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb/bitstreams"
       },
       "self" : {
-        "href" : "https://api7.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb"
+        "href" : "https://demo.dspace.org/server/api/core/bundles/d3599177-0408-403b-9f8d-d300edd79edb"
       }
     }
   }
@@ -388,7 +388,7 @@ This endpoint is relevant to:
 
 **POST /api/core/items/<:uuid>/bundles**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/bundles>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/bundles>
 
 Creating a new bundle in an item would use JSON similar to the example below:
 
@@ -414,7 +414,7 @@ Status codes:
 ### Owning Collection
 **/api/core/items/<:uuid>/owningCollection**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/owningCollection>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/owningCollection>
 
 It returns the collection where the item belong to
 
@@ -424,7 +424,7 @@ The actual collection is part of the body using the uri-list. Note that if the p
 
 Example:
 
-```curl -i -X PUT "https://api7.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/owningCollection" -H "Content-Type:text/uri-list" -d "https://api7.dspace.org/server/api/core/collections/8e0928a0-047a-4369-8883-12669f32dd64"```
+```curl -i -X PUT "https://demo.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/owningCollection" -H "Content-Type:text/uri-list" -d "https://demo.dspace.org/server/api/core/collections/8e0928a0-047a-4369-8883-12669f32dd64"```
 
 It updates the owning collection (moves the item).
 
@@ -442,7 +442,7 @@ It returns all the mapped collections the item is included in.
 On the item page, it should be referenced similar to:
 ```json
     "mappedCollections": {
-      "href": "https://api7.dspace.org/server/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappedCollections"
+      "href": "https://demo.dspace.org/server/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappedCollections"
     }
 ```
 
@@ -456,8 +456,8 @@ A POST request will result in creating a new mapping between the item and collec
 If the collection exists and is neither the owning nor mapped collection for the item, the relation should be created.
 
 ```
- curl -i -X POST https://api7.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections 
- -H "Content-Type:text/uri-list" --data "https://api7.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+ curl -i -X POST https://demo.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections 
+ -H "Content-Type:text/uri-list" --data "https://demo.dspace.org/server/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
 ```
 
 The collection(s) MUST be included in the body using the `text/uri-list` content type
@@ -483,7 +483,7 @@ A DELETE request will result in removing an existing mapping between the item an
 If the collection exists and is a mapped collection for the item, the relation should be deleted.
 
 ```
- curl -i -X DELETE https://api7.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+ curl -i -X DELETE https://demo.dspace.org/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
 ```
 
 The above request would remove the mapping between Collection with UUID `1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb` and Item with UUID `1911e8a4-6939-490c-b58b-a5d70f8d91fb`.
@@ -506,7 +506,7 @@ It returns the collection that have the item as template
 ### Relationships per item
 **/api/core/items/<:uuid>/relationships**
 
-A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-b8a2-f00ede62c60a/relationships
+A sample can be found at https://demo.dspace.org/#https://demo.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-b8a2-f00ede62c60a/relationships
 
 It embeds all relationships where either the left or the right item matches the given uuid
 

--- a/itemtemplates.md
+++ b/itemtemplates.md
@@ -53,7 +53,7 @@ A collection's item template can be deleted, automatically ensuring the relation
 
 Curl example:
 ```
-curl 'https://api7.dspace.org/server/api/core/itemtemplates/34d343c5-feb7-4a54-b07f-20a92debe061' \
+curl 'https://demo.dspace.org/server/api/core/itemtemplates/34d343c5-feb7-4a54-b07f-20a92debe061' \
  -XDELETE \
  -H 'Authorization: Bearer eyJhbGciOiJI...'
 ```

--- a/metadatafields.md
+++ b/metadatafields.md
@@ -6,7 +6,7 @@
 
 Provide access to the metadata fields defined in the registry (DBMS based). It returns the list of existent metadata fields.
 
-Example: <https://api7.dspace.org/server/#/server/api/core/metadatafields>
+Example: <https://demo.dspace.org/server/#/server/api/core/metadatafields>
 
 ## Single Metadata Field
 **/api/core/metadatafields/<:id>**
@@ -29,7 +29,7 @@ Exposed links:
 ### Schema
 **/api/core/metadatafields/<:id>/schema**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/metadatafields/8/schema>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/metadatafields/8/schema>
 
 It returns the metadata schema which the metadata field belongs. See the Metadata Schema endpoint for more info](metadataschemas.md#Single Metadata Schema)
 
@@ -38,7 +38,7 @@ It returns the metadata schema which the metadata field belongs. See the Metadat
 #### bySchema
 **/api/core/metadatafields/search/bySchema?schema=<:prefix>**
 
-Example: <https://api7.dspace.org/server/#https://api7.dspace.org/server/api/core/metadatafields/search/bySchema?schema=dc>
+Example: <https://demo.dspace.org/server/#https://demo.dspace.org/server/api/core/metadatafields/search/bySchema?schema=dc>
 
 The supported parameters are:
 * **(mandatory)** schema, the prefix of the metadata schema (i.e. "dc", "dcterms", "eperson, etc.)

--- a/metadataschemas.md
+++ b/metadataschemas.md
@@ -6,7 +6,7 @@
 
 Provide access to the metadata schemas defined in the registry (DBMS based). It returns the list of existent metadata schemas.
 
-Example: <https://api7.dspace.org/server/#/server/api/core/metadataschemas>
+Example: <https://demo.dspace.org/server/#/server/api/core/metadataschemas>
 
 ## Single Metadata Schema
 **/api/core/metadataschemas/<:id>**
@@ -20,7 +20,7 @@ Provide detailed information about a specific metadata schema. The JSON response
   "type": "metadataschema",
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/metadataschemas/1"
+      "href": "https://demo.dspace.org/server/api/core/metadataschemas/1"
     }
   }
 }

--- a/orcidhistories.md
+++ b/orcidhistories.md
@@ -55,7 +55,7 @@ Return codes:
 
 An example curl call:
 ```
- curl -i -X POST https://api7.dspace.org/server/api/eperson/orcidhistories \
+ curl -i -X POST https://demo.dspace.org/server/api/eperson/orcidhistories \
  -H "Content-Type:text/uri-list" \
- --data "https://api7.dspace.org/server/api/eperson/orcidqueues/10"
+ --data "https://demo.dspace.org/server/api/eperson/orcidqueues/10"
 ```

--- a/relationships.md
+++ b/relationships.md
@@ -7,12 +7,12 @@ It uses a [relationship type](relationshiptypes.md) and the 2 items with HAL lin
 ## Main Endpoint
 **/api/core/relationships**
 
-A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server/api/core/relationshiptypes
+A sample can be found at https://demo.dspace.org/#https://demo.dspace.org/server/api/core/relationshiptypes
 
 ## Single Relationship
 **/api/core/relationships/<:id>**
 
-A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server/api/core/relationships/1117
+A sample can be found at https://demo.dspace.org/#https://demo.dspace.org/server/api/core/relationships/1117
 
 ```json
 {
@@ -23,16 +23,16 @@ A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server
   "type": "relationship",
   "_links": {
     "relationshipType": {
-      "href": "https://api7.dspace.org/server/api/core/relationships/530/relationshipType"
+      "href": "https://demo.dspace.org/server/api/core/relationships/530/relationshipType"
     },
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/relationships/530"
+      "href": "https://demo.dspace.org/server/api/core/relationships/530"
     },
     "leftItem": {
-      "href": "https://api7.dspace.org/server/api/core/items/e98b0f27-5c19-49a0-960d-eb6ad5287067"
+      "href": "https://demo.dspace.org/server/api/core/items/e98b0f27-5c19-49a0-960d-eb6ad5287067"
     },
     "rightItem": {
-      "href": "https://api7.dspace.org/server/api/core/items/0ffbee3f-e7ea-42bc-92fe-2fbef1a52c0f"
+      "href": "https://demo.dspace.org/server/api/core/items/0ffbee3f-e7ea-42bc-92fe-2fbef1a52c0f"
     }
   },
   "_embedded": {
@@ -47,13 +47,13 @@ A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server
       "type": "relationshiptype",
       "_links": {
         "leftType": {
-          "href": "https://api7.dspace.org/server/api/core/entitytypes/1"
+          "href": "https://demo.dspace.org/server/api/core/entitytypes/1"
         },
         "rightType": {
-          "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+          "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
         },
         "self": {
-          "href": "https://api7.dspace.org/server/api/core/relationshiptypes/1"
+          "href": "https://demo.dspace.org/server/api/core/relationshiptypes/1"
         }
       },
       "_embedded": {
@@ -63,10 +63,10 @@ A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server
           "type": "entitytype",
           "_links": {
             "self": {
-              "href": "https://api7.dspace.org/server/api/core/entitytypes/1"
+              "href": "https://demo.dspace.org/server/api/core/entitytypes/1"
             },
             "relationshiptypes": {
-              "href": "https://api7.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
+              "href": "https://demo.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
             }
           }
         },
@@ -76,10 +76,10 @@ A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server
           "type": "entitytype",
           "_links": {
             "self": {
-              "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+              "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
             },
             "relationshiptypes": {
-              "href": "https://api7.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
+              "href": "https://demo.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
             }
           }
         }
@@ -126,12 +126,12 @@ A new relationship between 2 items can be created by specifying both items in a 
 
 A sample CURL command would be:
 ```
-curl -i -X POST 'https://api7.dspace.org/server/api/core/relationships?relationshipType=1' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://api7.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
+curl -i -X POST 'https://demo.dspace.org/server/api/core/relationships?relationshipType=1' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://demo.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
 ```
 
 Including a name variant would result in:
 ```
-curl -i -X POST 'https://api7.dspace.org/server/api/core/relationships?relationshipType=1&leftwardValue=Name%20variant%201' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://api7.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
+curl -i -X POST 'https://demo.dspace.org/server/api/core/relationships?relationshipType=1&leftwardValue=Name%20variant%201' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://demo.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
 ```
 
 The uri-list should always contain exactly 2 items. The first item will be used as the left Item. The second item will be used as the right Item.
@@ -150,12 +150,12 @@ Update the items in the relationship
 
 A sample CURL command to update the left item would be:
 ```
-curl -i -X PUT 'https://api7.dspace.org/server/api/core/relationships/891/leftItem' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e'
+curl -i -X PUT 'https://demo.dspace.org/server/api/core/relationships/891/leftItem' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e'
 ```
 
 A sample CURL command to update the right item would be:
 ```
-curl -i -X PUT 'https://api7.dspace.org/server/api/core/relationships/891/rightItem' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
+curl -i -X PUT 'https://demo.dspace.org/server/api/core/relationships/891/rightItem' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
 ```
 
 The uri-list should always contain exactly 1 item. This item will be used as to replace the left of right item, depending on whether the URL ends with /leftItem or /rightItem
@@ -175,7 +175,7 @@ Error codes:
 
 Update the name variant or the place:
 ```
-curl -i -X PUT 'https://api7.dspace.org/server/api/core/relationships/891' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:application/json" --data '{ "leftPlace": 1, "leftwardValue": "Smith, Jane", "rightPlace": 1, "rightwardValue": null }'
+curl -i -X PUT 'https://demo.dspace.org/server/api/core/relationships/891' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:application/json" --data '{ "leftPlace": 1, "leftwardValue": "Smith, Jane", "rightPlace": 1, "rightwardValue": null }'
 ```
 
 Omitted properties will be removed.
@@ -189,7 +189,7 @@ Error codes:
 ## Relationships per Relationship type
 **/api/core/relationships/search/byLabel?label=<:relationshipname>**
 
-A sample search would be https://api7.dspace.org/#https://api7.dspace.org/server/api/core/relationships/search/byLabel?label=isPersonOfOrgUnit
+A sample search would be https://demo.dspace.org/#https://demo.dspace.org/server/api/core/relationships/search/byLabel?label=isPersonOfOrgUnit
 The relationshipname parameter is mandatory
 
 It would respond with
@@ -206,16 +206,16 @@ It would respond with
         "type": "relationship",
         "_links": {
           "relationshipType": {
-            "href": "https://api7.dspace.org/server/api/core/relationships/590/relationshipType"
+            "href": "https://demo.dspace.org/server/api/core/relationships/590/relationshipType"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/core/relationships/590"
+            "href": "https://demo.dspace.org/server/api/core/relationships/590"
           },
           "leftItem": {
-            "href": "https://api7.dspace.org/server/api/core/items/f2235aa6-6fe7-4174-a690-598b72dd8e44"
+            "href": "https://demo.dspace.org/server/api/core/items/f2235aa6-6fe7-4174-a690-598b72dd8e44"
           },
           "rightItem": {
-            "href": "https://api7.dspace.org/server/api/core/items/d30de96b-1e76-40ae-8ef9-ab426b6f9763"
+            "href": "https://demo.dspace.org/server/api/core/items/d30de96b-1e76-40ae-8ef9-ab426b6f9763"
           }
         },
         "_embedded": {
@@ -230,13 +230,13 @@ It would respond with
             "type": "relationshiptype",
             "_links": {
               "leftType": {
-                "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+                "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
               },
               "rightType": {
-                "href": "https://api7.dspace.org/server/api/core/entitytypes/4"
+                "href": "https://demo.dspace.org/server/api/core/entitytypes/4"
               },
               "self": {
-                "href": "https://api7.dspace.org/server/api/core/relationshiptypes/5"
+                "href": "https://demo.dspace.org/server/api/core/relationshiptypes/5"
               }
             },
             "_embedded": {
@@ -246,10 +246,10 @@ It would respond with
                 "type": "entitytype",
                 "_links": {
                   "self": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
                   },
                   "relationshiptypes": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
                   }
                 }
               },
@@ -259,10 +259,10 @@ It would respond with
                 "type": "entitytype",
                 "_links": {
                   "self": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/4"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/4"
                   },
                   "relationshiptypes": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/4/relationshiptypes"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/4/relationshiptypes"
                   }
                 }
               }
@@ -279,16 +279,16 @@ It would respond with
         "type": "relationship",
         "_links": {
           "relationshipType": {
-            "href": "https://api7.dspace.org/server/api/core/relationships/589/relationshipType"
+            "href": "https://demo.dspace.org/server/api/core/relationships/589/relationshipType"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/core/relationships/589"
+            "href": "https://demo.dspace.org/server/api/core/relationships/589"
           },
           "leftItem": {
-            "href": "https://api7.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-b8a2-f00ede62c60a"
+            "href": "https://demo.dspace.org/server/api/core/items/5a3f7c7a-d3df-419c-b8a2-f00ede62c60a"
           },
           "rightItem": {
-            "href": "https://api7.dspace.org/server/api/core/items/c216201f-ed10-4361-b0e0-5a065405bd3e"
+            "href": "https://demo.dspace.org/server/api/core/items/c216201f-ed10-4361-b0e0-5a065405bd3e"
           }
         },
         "_embedded": {
@@ -303,13 +303,13 @@ It would respond with
             "type": "relationshiptype",
             "_links": {
               "leftType": {
-                "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+                "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
               },
               "rightType": {
-                "href": "https://api7.dspace.org/server/api/core/entitytypes/4"
+                "href": "https://demo.dspace.org/server/api/core/entitytypes/4"
               },
               "self": {
-                "href": "https://api7.dspace.org/server/api/core/relationshiptypes/5"
+                "href": "https://demo.dspace.org/server/api/core/relationshiptypes/5"
               }
             },
             "_embedded": {
@@ -319,10 +319,10 @@ It would respond with
                 "type": "entitytype",
                 "_links": {
                   "self": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
                   },
                   "relationshiptypes": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
                   }
                 }
               },
@@ -332,10 +332,10 @@ It would respond with
                 "type": "entitytype",
                 "_links": {
                   "self": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/4"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/4"
                   },
                   "relationshiptypes": {
-                    "href": "https://api7.dspace.org/server/api/core/entitytypes/4/relationshiptypes"
+                    "href": "https://demo.dspace.org/server/api/core/entitytypes/4/relationshiptypes"
                   }
                 }
               }
@@ -348,7 +348,7 @@ It would respond with
   },
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/relationships/search/byLabel?label=isPersonOfOrgUnit"
+      "href": "https://demo.dspace.org/server/api/core/relationships/search/byLabel?label=isPersonOfOrgUnit"
     }
   },
   "page": {
@@ -367,7 +367,7 @@ It embeds all relationships where the relationship type has the given label on e
 
 
 This can be further filtered to a single DSO using 
-https://api7.dspace.org/#https://api7.dspace.org/server/api/core/relationships/search/byLabel?label=isPersonOfOrgUnit&dso=f2235aa6-6fe7-4174-a690-598b72dd8e44 which contains all relationships created using the relationship type isPersonOfOrgUnit for which one item is f2235aa6-6fe7-4174-a690-598b72dd8e44
+https://demo.dspace.org/#https://demo.dspace.org/server/api/core/relationships/search/byLabel?label=isPersonOfOrgUnit&dso=f2235aa6-6fe7-4174-a690-598b72dd8e44 which contains all relationships created using the relationship type isPersonOfOrgUnit for which one item is f2235aa6-6fe7-4174-a690-598b72dd8e44
 The dso parameter is optional
 
 ## Deleting a relationship
@@ -378,7 +378,7 @@ Delete a relationship between 2 items.
 
 A sample CURL command would be:
 ```
-curl -D - -XDELETE 'https://api7.dspace.org/server/api/core/relationships/890'  -H 'Authorization: Bearer eyJhbGciO…'
+curl -D - -XDELETE 'https://demo.dspace.org/server/api/core/relationships/890'  -H 'Authorization: Bearer eyJhbGciO…'
 ```
 
 An optional parameter for copying virtual metadata to actual metadata in the related items can be included (only authorized if the user has permissions to update the metadata of the given items): `copyVirtualMetadata`. This can contain values:

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -8,12 +8,12 @@ A HAL link to the item types is embedded as well
 ## Main Endpoint
 **/api/core/relationshiptypes**
 
-A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server/api/core/relationshiptypes
+A sample can be found at https://demo.dspace.org/#https://demo.dspace.org/server/api/core/relationshiptypes
 
 ## Single Relationship Type
 **/api/core/relationshiptypes/<:id>**
 
-A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server/api/core/relationshiptypes/1
+A sample can be found at https://demo.dspace.org/#https://demo.dspace.org/server/api/core/relationshiptypes/1
 
 ```json
 {
@@ -27,13 +27,13 @@ A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server
   "type": "relationshiptype",
   "_links": {
     "leftType": {
-      "href": "https://api7.dspace.org/server/api/core/entitytypes/1"
+      "href": "https://demo.dspace.org/server/api/core/entitytypes/1"
     },
     "rightType": {
-      "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+      "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
     },
     "self": {
-      "href": "https://api7.dspace.org/server/api/core/relationshiptypes/1"
+      "href": "https://demo.dspace.org/server/api/core/relationshiptypes/1"
     }
   },
   "_embedded": {
@@ -43,10 +43,10 @@ A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server
       "type": "entitytype",
       "_links": {
         "self": {
-          "href": "https://api7.dspace.org/server/api/core/entitytypes/1"
+          "href": "https://demo.dspace.org/server/api/core/entitytypes/1"
         },
         "relationshiptypes": {
-          "href": "https://api7.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
+          "href": "https://demo.dspace.org/server/api/core/entitytypes/1/relationshiptypes"
         }
       }
     },
@@ -56,10 +56,10 @@ A sample can be found at https://api7.dspace.org/#https://api7.dspace.org/server
       "type": "entitytype",
       "_links": {
         "self": {
-          "href": "https://api7.dspace.org/server/api/core/entitytypes/2"
+          "href": "https://demo.dspace.org/server/api/core/entitytypes/2"
         },
         "relationshiptypes": {
-          "href": "https://api7.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
+          "href": "https://demo.dspace.org/server/api/core/entitytypes/2/relationshiptypes"
         }
       }
     }

--- a/resourcepolicies.md
+++ b/resourcepolicies.md
@@ -311,7 +311,7 @@ Update the eperson linked by this resource policy
 
 Sample CURL command:
 ```
-curl -i -X PUT 'https://api7.dspace.org/server/api/authz/resourcepolicies/3/eperson' -H 'Authorization: Bearer eyJhbGciOiJ…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/eperson/epersons/ba05e3dd-aa20-4441-ac05-8ceef6f67ac7'
+curl -i -X PUT 'https://demo.dspace.org/server/api/authz/resourcepolicies/3/eperson' -H 'Authorization: Bearer eyJhbGciOiJ…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/eperson/epersons/ba05e3dd-aa20-4441-ac05-8ceef6f67ac7'
 ```
 The uri-list should always contain exactly 1 eperson. This eperson will be assigned to the resource policy
 
@@ -343,7 +343,7 @@ Update the group linked by this resource policy
 
 Sample CURL command:
 ```
-curl -i -X PUT 'https://api7.dspace.org/server/api/authz/resourcepolicies/4/group' -H 'Authorization: Bearer eyJhbGciOiJ…' -H "Content-Type:text/uri-list" --data 'https://api7.dspace.org/server/api/eperson/groups/db337ae5-abd2-4a28-b4ad-918cf7779e25'
+curl -i -X PUT 'https://demo.dspace.org/server/api/authz/resourcepolicies/4/group' -H 'Authorization: Bearer eyJhbGciOiJ…' -H "Content-Type:text/uri-list" --data 'https://demo.dspace.org/server/api/eperson/groups/db337ae5-abd2-4a28-b4ad-918cf7779e25'
 ```
 The uri-list should always contain exactly 1 group. This group will be assigned to the resource policy
 

--- a/search-endpoint.md
+++ b/search-endpoint.md
@@ -694,7 +694,7 @@ The JSON response document is as follow
         "hasMinMaxValues": true,
         "_links": {
           "self": {
-            "href": "https://api7.dspace.org/server/api/discover/facets/dateissued"
+            "href": "https://demo.dspace.org/server/api/discover/facets/dateissued"
           }
         }
       },
@@ -704,7 +704,7 @@ The JSON response document is as follow
         "facetLimit": 2,
         "_links": {
           "self": {
-            "href": "https://api7.dspace.org/server/api/discover/facets/has_content_in_original_bundle"
+            "href": "https://demo.dspace.org/server/api/discover/facets/has_content_in_original_bundle"
           }
         }
       }
@@ -817,7 +817,7 @@ Example
   "type" : "discover",
   "_links" : {
     "self" : {
-      "href" : "https://api7.dspace.org/server/api/discover/search/objects?configuration=workspace"
+      "href" : "https://demo.dspace.org/server/api/discover/search/objects?configuration=workspace"
     }
   },
   "_embedded" : {
@@ -828,7 +828,7 @@ Example
           "type" : "discover",
           "_links" : {
             "indexableObject" : {
-              "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/8"
+              "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/8"
             }
           },
           "_embedded" : {
@@ -864,19 +864,19 @@ Example
               "type" : "workspaceitem",
               "_links" : {
                 "collection" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/8/collection"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/8/collection"
                 },
                 "item" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/8/item"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/8/item"
                 },
                 "submissionDefinition" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/8/submissionDefinition"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/8/submissionDefinition"
                 },
                 "submitter" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/8/submitter"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/8/submitter"
                 },
                 "self" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/8"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/8"
                 }
               },
               "_embedded" : {
@@ -898,7 +898,7 @@ Example
           "type" : "discover",
           "_links" : {
             "indexableObject" : {
-              "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/9"
+              "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/9"
             }
           },
           "_embedded" : {
@@ -934,19 +934,19 @@ Example
               "type" : "workspaceitem",
               "_links" : {
                 "collection" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/9/collection"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/9/collection"
                 },
                 "item" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/9/item"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/9/item"
                 },
                 "submissionDefinition" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/9/submissionDefinition"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/9/submissionDefinition"
                 },
                 "submitter" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/9/submitter"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/9/submitter"
                 },
                 "self" : {
-                  "href" : "https://api7.dspace.org/server/api/submission/workspaceitems/9"
+                  "href" : "https://demo.dspace.org/server/api/submission/workspaceitems/9"
                 }
               },
               "_embedded" : {
@@ -968,7 +968,7 @@ Example
           "type" : "discover",
           "_links" : {
             "indexableObject" : {
-              "href" : "https://api7.dspace.org/server/api/workflow/workflowitems/3"
+              "href" : "https://demo.dspace.org/server/api/workflow/workflowitems/3"
             }
           },
           "_embedded" : {
@@ -1004,19 +1004,19 @@ Example
               "type" : "workflowitem",
               "_links" : {
                 "collection" : {
-                  "href" : "https://api7.dspace.org/server/api/workflow/workflowitems/3/collection"
+                  "href" : "https://demo.dspace.org/server/api/workflow/workflowitems/3/collection"
                 },
                 "item" : {
-                  "href" : "https://api7.dspace.org/server/api/workflow/workflowitems/3/item"
+                  "href" : "https://demo.dspace.org/server/api/workflow/workflowitems/3/item"
                 },
                 "submissionDefinition" : {
-                  "href" : "https://api7.dspace.org/server/api/workflow/workflowitems/3/submissionDefinition"
+                  "href" : "https://demo.dspace.org/server/api/workflow/workflowitems/3/submissionDefinition"
                 },
                 "submitter" : {
-                  "href" : "https://api7.dspace.org/server/api/workflow/workflowitems/3/submitter"
+                  "href" : "https://demo.dspace.org/server/api/workflow/workflowitems/3/submitter"
                 },
                 "self" : {
-                  "href" : "https://api7.dspace.org/server/api/workflow/workflowitems/3"
+                  "href" : "https://demo.dspace.org/server/api/workflow/workflowitems/3"
                 }
               },
 			"_embedded" : {
@@ -1038,7 +1038,7 @@ Example
       },
       "_links" : {
         "self" : {
-          "href" : "https://api7.dspace.org/server/api/discover/search/objects?configuration=workspace"
+          "href" : "https://demo.dspace.org/server/api/discover/search/objects?configuration=workspace"
         }
       },
       "page" : {
@@ -1054,7 +1054,7 @@ Example
       "facetLimit" : 10,
       "_links" : {
         "self" : {
-          "href" : "https://api7.dspace.org/server/api/discover/facets/namedresourcetype?configuration=workspace"
+          "href" : "https://demo.dspace.org/server/api/discover/facets/namedresourcetype?configuration=workspace"
         }
       },
       "page" : {
@@ -1068,7 +1068,7 @@ Example
           "type" : "discover",
           "_links" : {
             "search" : {
-              "href" : "https://api7.dspace.org/server/api/discover/search/objects?configuration=workspace&f.namedresourcetype=workspace,authority"
+              "href" : "https://demo.dspace.org/server/api/discover/search/objects?configuration=workspace&f.namedresourcetype=workspace,authority"
             }
           }
         }, {
@@ -1077,7 +1077,7 @@ Example
           "type" : "discover",
           "_links" : {
             "search" : {
-              "href" : "https://api7.dspace.org/server/api/discover/search/objects?configuration=workspace&f.namedresourcetype=workflow,authority"
+              "href" : "https://demo.dspace.org/server/api/discover/search/objects?configuration=workspace&f.namedresourcetype=workflow,authority"
             }
           }
         } ]
@@ -1088,7 +1088,7 @@ Example
       "facetLimit" : 10,
       "_links" : {
         "self" : {
-          "href" : "https://api7.dspace.org/server/api/discover/facets/itemtype?configuration=workspace"
+          "href" : "https://demo.dspace.org/server/api/discover/facets/itemtype?configuration=workspace"
         }
       },
       "_embedded" : {
@@ -1102,7 +1102,7 @@ Example
       "maxValue" : "2010-11-03",
       "_links" : {
         "self" : {
-          "href" : "https://api7.dspace.org/server/api/discover/facets/dateIssued?configuration=workspace"
+          "href" : "https://demo.dspace.org/server/api/discover/facets/dateIssued?configuration=workspace"
         }
       },
       "page" : {
@@ -1116,7 +1116,7 @@ Example
           "type" : "discover",
           "_links" : {
             "search" : {
-              "href" : "https://api7.dspace.org/server/api/discover/search/objects?configuration=workspace&f.dateIssued=2010,equals"
+              "href" : "https://demo.dspace.org/server/api/discover/search/objects?configuration=workspace&f.dateIssued=2010,equals"
             }
           }
         } ]

--- a/supervisionorders.md
+++ b/supervisionorders.md
@@ -18,10 +18,10 @@ Provides information about a single supervision order defined into the system
   "id": 42,
   "_links": {
     "item": {
-      "href": "https://api7.dspace.org/server/api/core/items/092b59e8-8159-4e70-98b5-93ec60bd3431"
+      "href": "https://demo.dspace.org/server/api/core/items/092b59e8-8159-4e70-98b5-93ec60bd3431"
     },
     "group": {
-      "href": "https://api7.dspace.org/server/api/eperson/groups/4ebb837c-c2ae-4928-9bb1-6f51df4eeb60"
+      "href": "https://demo.dspace.org/server/api/eperson/groups/4ebb837c-c2ae-4928-9bb1-6f51df4eeb60"
     }
   }
 ```
@@ -69,7 +69,7 @@ The supported parameters are:
 
 A sample CURL command would be:
 ```
-curl -i -X POST 'https://api7.dspace.org/server/api/core/supervisionorders?uuid=<uuid>&group=<group uuid>&type=NONE' -H 'Authorization: Bearer eyJrasdfw…' 
+curl -i -X POST 'https://demo.dspace.org/server/api/core/supervisionorders?uuid=<uuid>&group=<group uuid>&type=NONE' -H 'Authorization: Bearer eyJrasdfw…' 
 ```
 
 * 201 Created - if the operation succeed
@@ -87,7 +87,7 @@ Delete a supervision order.
 
 A sample CURL command would be:
 ```
-curl -D - -XDELETE 'https://api7.dspace.org/server/api/core/supervisionorders/42'  -H 'Authorization: Bearer eyJhafsdf…'
+curl -D - -XDELETE 'https://demo.dspace.org/server/api/core/supervisionorders/42'  -H 'Authorization: Bearer eyJhafsdf…'
 ```
 
 Return codes:

--- a/vocabularies.md
+++ b/vocabularies.md
@@ -22,10 +22,10 @@ Example:
         "type": "vocabulary",
         "_links": {
           "entries": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularies/srsc/entries"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularies/srsc/entries"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularies/srsc"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularies/srsc"
           }
         }
       },
@@ -37,10 +37,10 @@ Example:
         "type": "vocabulary",
         "_links": {
           "entries": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularies/srsc/entries"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularies/srsc/entries"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularies/srsc"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularies/srsc"
           }
         }
       },
@@ -52,10 +52,10 @@ Example:
         "type": "vocabulary",
         "_links": {
           "entries": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_iso_languages/entries"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_iso_languages/entries"
           },
           "self": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_iso_languages"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_iso_languages"
           }
         }
       }
@@ -63,7 +63,7 @@ Example:
   },
   "_links": {
     "self": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies"
     }
   },
   "page": {
@@ -142,16 +142,16 @@ sample for the vocabulary common_types defined via a value pairs in the submissi
   },
   "_links": {
     "first": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?page=0&size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?page=0&size=2"
     },
     "self": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?size=2"
     },
     "next": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?page=1&size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?page=1&size=2"
     },
     "last": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?page=10&size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?page=10&size=2"
     }
   },
   "page": {
@@ -183,13 +183,13 @@ extra sample filtering the suggestion with the term Book
   },
   "_links": {
     "first": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?page=0&size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?page=0&size=2"
     },
     "self": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?size=2"
     },
     "last": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?page=0&size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?page=0&size=2"
     }
   },
   "page": {
@@ -220,7 +220,7 @@ sample for a hierarchical authority  (srsc):
         "type": "vocabularyEntry",
         "_links": {
           "vocabularyEntryDetail": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularyEntryDetails/srsc:VR131402"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularyEntryDetails/srsc:VR131402"
           }
         }
       },
@@ -236,7 +236,7 @@ sample for a hierarchical authority  (srsc):
         "type": "vocabularyEntry",
         "_links": {
           "vocabularyEntryDetail": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularyEntryDetails/srsc:VR131403"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularyEntryDetails/srsc:VR131403"
           }
         }
       }
@@ -244,16 +244,16 @@ sample for a hierarchical authority  (srsc):
   },
   "_links": {
     "first": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2&page=0"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2&page=0"
     },
     "self": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2"
     },
     "next": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2&page=1"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2&page=1"
     },
     "last": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2&page=12"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/common_types/entries?filter=Research&size=2&page=12"
     }
   },
   "page": {
@@ -279,20 +279,20 @@ sample for a vocabulary providing an authority value
         "type": "vocabularyEntry",
         "_links": {
           "vocabularyEntryDetail": {
-            "href": "https://api7.dspace.org/server/api/submission/vocabularyEntryDetails/SolrAuthorAuthority:42768ba6-0ba1-4aa3-971e-9c4e27fd7558"
+            "href": "https://demo.dspace.org/server/api/submission/vocabularyEntryDetails/SolrAuthorAuthority:42768ba6-0ba1-4aa3-971e-9c4e27fd7558"
           }
         }
       }]
   },
   "_links": {
     "first": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/SolrAuthorAuthority/entries?page=0&size=1"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/SolrAuthorAuthority/entries?page=0&size=1"
     },
     "self": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/SolrAuthorAuthority/entries?size=1"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/SolrAuthorAuthority/entries?size=1"
     },
     "last": {
-      "href": "https://api7.dspace.org/server/api/submission/vocabularies/SolrAuthorAuthority/entries?page=0&size=1"
+      "href": "https://demo.dspace.org/server/api/submission/vocabularies/SolrAuthorAuthority/entries?page=0&size=1"
     }
   },
   "page": {

--- a/workflowitems.md
+++ b/workflowitems.md
@@ -34,7 +34,7 @@ Provide detailed information about a specific workflowitem. The JSON response do
   	 },
   	 "license": {
   	 	acceptanceDate: "2017-06-24T00:40:54.970+0000",
-  	 	url: "https://api7.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/content"
+  	 	url: "https://demo.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/content"
   	 },
   	 "uploads": [ 
   	 	{
@@ -47,7 +47,7 @@ Provide detailed information about a specific workflowitem. The JSON response do
 			    "checkSumAlgorithm": "MD5",
 			    "value": "9d8f0f9e369cf12159d47c146c499cf4"
 			},
-  	 		"url": "https://api7.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
+  	 		"url": "https://demo.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
   	 		"accessConditions": [
   	 			{
   	 				"id": 123,

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -20,7 +20,7 @@ Provide detailed information about a specific workflow step. An example JSON res
   	"type": "workflowstep",
     "_links": {
       "workflowactions": {
-        "href": "https://api7.dspace.org/server/api/config/workflowsteps/<:step-name>/workflowactions"
+        "href": "https://demo.dspace.org/server/api/config/workflowsteps/<:step-name>/workflowactions"
       }
     },
     "_embedded": {

--- a/workspaceitem-data-license.md
+++ b/workspaceitem-data-license.md
@@ -6,7 +6,7 @@ The section data represent the data about the granted deposit license
 ```json
 {
   	"granted": true,
-  	"url": "https://api7.dspace.org/server/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
+  	"url": "https://demo.dspace.org/server/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
     "acceptanceDate": "2017-11-20T10:32:42Z"
 }
 ```
@@ -71,7 +71,7 @@ will result in
 		"license":
 			{
 				"granted": true,
-			  	"url": "https://api7.dspace.org/server/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
+			  	"url": "https://demo.dspace.org/server/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
 			    "acceptanceDate": "2017-11-20T10:32:42Z"
 			}
 		...
@@ -116,7 +116,7 @@ trasforming
 		"license":
 			{
 				"granted": true,
-			  	"url": "https://api7.dspace.org/server/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
+			  	"url": "https://demo.dspace.org/server/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
 			    "acceptanceDate": "2017-11-20T10:32:42Z"
 			}
 		...

--- a/workspaceitem-data-upload.md
+++ b/workspaceitem-data-upload.md
@@ -16,7 +16,7 @@ The section data represent the data about the user uploaded files
 			    "checkSumAlgorithm": "MD5",
 			    "value": "9d8f0f9e369cf12159d47c146c499cf4"
 			},
-  	 		"url": "https://api7.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
+  	 		"url": "https://demo.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
   	 		"accessConditions": [
   	 			{
   	 				"id": 123,
@@ -99,7 +99,7 @@ will set the title of the first uploaded file to MyFile.pdf returning the follow
 				    "checkSumAlgorithm": "MD5",
 				    "value": "9d8f0f9e369cf12159d47c146c499cf4"
 				},
-	  	 		"url": "https://api7.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
+	  	 		"url": "https://demo.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
 	  	 		"accessConditions": [
 	  	 			{
 	  	 				"id": 123,

--- a/workspaceitems.md
+++ b/workspaceitems.md
@@ -21,9 +21,9 @@ In the remote resource scenario, Multipart POST can include a uri-list containin
 
 An example curl call:
 ```
- curl -i -X POST https://api7.dspace.org/server/api/submission/workspaceitems?owningCollection=1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \
+ curl -i -X POST https://demo.dspace.org/server/api/submission/workspaceitems?owningCollection=1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \
  -H "Content-Type:text/uri-list" \
- --data "https://api7.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
+ --data "https://demo.dspace.org/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
 ```
 No confirmation, user has confirmed they want this record, and the previous state of the item is empty
 
@@ -41,7 +41,7 @@ There are some constraints to import files:
 
 An example curl call:
 
-    curl --location --request POST 'https://api7.dspace.org/server/api/submission/workspaceitems' 
+    curl --location --request POST 'https://demo.dspace.org/server/api/submission/workspaceitems' 
     --form 'file=@/path/to/bibtex-test.bib' --form 'file=@/path/to/pubmed-test.xml'
 
     
@@ -74,7 +74,7 @@ Provide detailed information about a specific workspaceitem. The JSON response d
   	 },
   	 "license": {
   	 	acceptanceDate: "2017-06-24T00:40:54.970+0000",
-  	 	url: "https://api7.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/content"
+  	 	url: "https://demo.dspace.org/server/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/content"
   	 },
   	 "uploads": [ 
   	 	{
@@ -87,7 +87,7 @@ Provide detailed information about a specific workspaceitem. The JSON response d
 			    "checkSumAlgorithm": "MD5",
 			    "value": "9d8f0f9e369cf12159d47c146c499cf4"
 			},
-  	 		"url": "https://api7.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
+  	 		"url": "https://demo.dspace.org/server/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
   	 		"accessConditions": [
   	 			{
   	 				"id": 123,


### PR DESCRIPTION
Replace references to api7.dspace.org with demo.dspace.org now that the demo server is running DSpace 7.