### PR TITLE
Contract for `isNotMemberOf` searches for Groups and EPersons

### DIFF
--- a/epersongroups.md
+++ b/epersongroups.md
@@ -327,13 +327,39 @@ Return codes:
 * 404 Not found - if the parent group doesn't exist
 * 422 Unprocessable Entity - if the child group doesn't exist or if the specified eperson doesn't exist
 
-## Search
-**GET /api/eperson/groups/search/byMetadata?query=<:name>**
+## Search Methods
 
-This supports a basic search in the metadata.
+### byMetadata
+**GET /api/eperson/groups/search/byMetadata?query=<:string>**
+
+This supports a basic search across all Groups via their metadata.
 It will search in:
 * UUID (exact match)
 * group name
+
+It returns the list of GroupRest instances, if any, matching the user query
+
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the 'query' parameter is missing or invalid
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators or Community/Collection administrators can use this endpoint.
+
+### isNotMemberOf
+**GET /api/eperson/groups/search/isNotMemberOf?group=<:uuid>&query=<:string>**
+
+This supports a basic search across all Groups which are not already a member (subgroup) of the provided Group (in the 'group' parameter). Therefore it searches across Groups _not already listed_ on the `/api/eperson/groups/<:uuid>/subgroups` endpoint for the provided group.
+It will search in:
+* UUID (exact match)
+* group name
+
+It returns the list of GroupRest instances, if any, matching the user query
+
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the 'group' or 'query' parameter is missing or invalid
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators or Community/Collection administrators can use this endpoint.
 
 ## Related DSpace Object of group
 **GET /api/eperson/groups/<:uuid>/object** (READ-ONLY)

--- a/epersons.md
+++ b/epersons.md
@@ -99,7 +99,9 @@ Return codes:
 This supports a basic search across all EPersons which are not already a member of the provided Group (in the 'group' parameter). Therefore it searches EPersons _not already listed_ on the `/api/eperson/groups/<:uuid>/epersons` endpoint for the provided group.
 It will search in:
 * UUID (exact match)
-* group name
+* first name
+* last name
+* email address
 
 It returns the list of EPersonRest instances, if any, matching the user query
 

--- a/epersons.md
+++ b/epersons.md
@@ -60,8 +60,8 @@
 }
 ```
 
-### Search methods
-#### byEmail
+## Search methods
+### byEmail
 **/api/eperson/epersons/search/byEmail?email=<:string>**
 
 The supported parameters are:
@@ -75,10 +75,10 @@ Return codes:
 * 401 Unauthorized - if you are not authenticated
 * 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators and users with READ rights on the target EPerson can use the endpoint
 
-#### byMetadata
-**GET /api/eperson/epersons/search/byMetadata?query=<:name>**
+### byMetadata
+**GET /api/eperson/epersons/search/byMetadata?query=<:string>**
 
-This supports a basic search in the metadata.
+This supports a basic search across all EPerson accounts via their metadata.
 It will search in:
 * UUID (exact match)
 * first name
@@ -89,9 +89,25 @@ It returns the list of EPersonRest instances, if any, matching the user query
 
 Return codes:
 * 200 OK - if the operation succeed
-* 400 Bad Request - if the email parameter is missing or invalid
+* 400 Bad Request - if the 'query' parameter is missing or invalid
 * 401 Unauthorized - if you are not authenticated
-* 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators and users with READ rights on the target EPerson can use the endpoint
+* 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators or Community/Collection administrators can use this endpoint.
+
+### isNotMemberOf
+**GET /api/eperson/epersons/search/isNotMemberOf?group=<:uuid>&query=<:string>**
+
+This supports a basic search across all EPersons which are not already a member of the provided Group (in the 'group' parameter). Therefore it searches EPersons _not already listed_ on the `/api/eperson/groups/<:uuid>/epersons` endpoint for the provided group.
+It will search in:
+* UUID (exact match)
+* group name
+
+It returns the list of EPersonRest instances, if any, matching the user query
+
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the 'group' or 'query' parameter is missing or invalid
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators or Community/Collection administrators can use this endpoint.
 
 ## Patch operations
 


### PR DESCRIPTION
(Replaces #237)

Required by https://github.com/DSpace/DSpace/issues/9052 and https://github.com/DSpace/dspace-angular/issues/2512

# Description

In order to fix the performance issues described in the above tickets, we need a way to search across _all Groups_ and _all EPersons_ which are **not yet a member of** a specific Group in the system.

Therefore, this PR suggests two new REST API endpoints:
1. `GET /api/eperson/groups/search/isNotMemberOf?group=<:uuid>&query=<:string>`
    * Will search across all Groups which are not yet a member of the Group specified by `group=<:uuid>`.
    * This is the same as searching all Groups which are NOT listed under the `/api/eperson/groups/<:uuid>/subgroups` endpoint for that Group specified by `group=<:uuid>` 
2. `GET /api/eperson/epersons/search/isNotMemberOf?group=<:uuid>&query=<:string>`
    * Will search across all EPersons which are not yet a member of the Group specified by `group=<:uuid>`.
    * This is the same as searching all EPersons which are NOT listed under the `/api/eperson/groups/<:uuid>/epersons` endpoint for that Group specified by `group=<:uuid>` 

# Additional Details on Performance Issue

These new endpoints are required to fix the behavior issues in the Angular UI code.  Currently, our Angular UI includes code which requests _every EPerson in a Group_ or _every Subgroup in a Group_ in order to determine whether a given EPerson or Group is already included in a given parent Group.

For example:
* `isMemberOfGroup` in `members-list.component.ts`: https://github.com/DSpace/dspace-angular/blob/main/src/app/access-control/group-registry/group-form/members-list/members-list.component.ts#L216C1-L233C3
* `isSubgroupOfGroup` in `subgroups-list.component.ts`: https://github.com/DSpace/dspace-angular/blob/main/src/app/access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts#L138-L159

This UI behavior will cause performance issues when a Group has a large number of members (either EPerson or Subgroup). 

This performance issue will be fixed by now creating performance-friendly endpoints to find *non-members*.