### PR TITLE
Revert "Return no content for unset properties"

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -21,6 +21,5 @@ The DSpace server will have a whitelist of properties that can be retrieved by t
 }
 ```          
 
-* 200 OK - if the operation succeeded
-* 204 No Content - if the property isn't configured to be retrieved
-* 404 Not found - if the property doesn't exist 
+* 200 OK - if the operation succeed
+* 404 Not found - if the property doesn't exist or isn't configured to be retrieved


### PR DESCRIPTION
Reverts DSpace/RestContract#243

As was noted in today's meeting by @J4bbi , I misunderstood the original PR.  I had thought it was a fix to incorrect documentation, but I now realize that the original contract was related to https://github.com/DSpace/DSpace/issues/9014 ... which is a larger change needing review.
