### PR TITLE
New 'creationTime' sort option for '/search/byProperty' in processes contract

### DIFF
--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -359,7 +359,7 @@ This supports a basic search of the processes
 
 The supported parameters are:
 * page, size [see pagination](README.md#Pagination)
-* sort, options are startTime, endTime
+* sort, options are startTime, endTime and creationTime
 * userId: optional, the uuid of the eperson who started the process. If not specified, all processes will be returned
 * scriptName: optional, limit the returned processes to the specified script
 * processStatus: optional, limit the returned processes to the specified status. The possible `status` values are `SCHEDULED`, `RUNNING`, `COMPLETED` and `FAILED`


### PR DESCRIPTION
## References

* Related to DSpace/dspace#9295

## Description

This PR updates the possible sort options for `/processes/search/byProperty`, as described in the REST PR above.

Note: I didn't have to add `creationTime` to the output examples as it was already there, even though this [isn't the case](https://demo.dspace.org/server/#https://demo.dspace.org/server/api/system/processes) at the moment.