### PR TITLE
Added missing required collection body parameters to PUT request

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -682,7 +682,7 @@ Provide updated metadata information about a specific collection, when the updat
 ```json
 {
   "uuid": "20263916-6a3d-4fdc-a44a-4616312f030c",
-  "name": "test collection",
+  "handle": "10673/2",
   "metadata": {
     "dc.title": [
       {
@@ -700,7 +700,8 @@ Provide updated metadata information about a specific collection, when the updat
         "confidence": -1
       }
     ]
-  }
+  },
+  "type": "collection"
 }
 ```  
 

--- a/communities.md
+++ b/communities.md
@@ -359,9 +359,7 @@ Provide updated metadata information about a specific community, when the update
 
 ```json
 {
-  "id": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
   "uuid": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
-  "name": "test new title",
   "handle": "123456789/60631",
   "metadata": {
     "dc.title": [

--- a/items.md
+++ b/items.md
@@ -186,9 +186,7 @@ Provide updated metadata information for an item, when the update is completed t
 
 ```json
 {
-  "id": "a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9",
   "uuid": "a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9",
-  "name": "Test new title",
   "handle": "123456789/60636",
   "metadata": {
     "dc.contributor.author": [
@@ -208,9 +206,6 @@ Provide updated metadata information for an item, when the update is completed t
       }
     ]
   },
-  "inArchive": true,
-  "discoverable": true,
-  "withdrawn": false,
   "type": "item"
 }
 ```


### PR DESCRIPTION
- Added missing required body parameters to collection PUT request
- Removed unnecessary body parameters from community/collection/item PUT requests. These were parameters that can't be updated with a PUT request and who aren't necessary to perform the request.