### PR TITLE
Remove obsoloete remark in resourcepolicies.md

### DIFF
--- a/resourcepolicies.md
+++ b/resourcepolicies.md
@@ -322,8 +322,6 @@ Return codes:
 
 Return the eperson linked by this resource policy
 
-The recipient of the policy, eperson or group, cannot be modified. If you need to do so please delete the policy and create a new one.
-
 Return codes:
 * 200 Ok - if the operation succeed and an eperson is set for this policy
 * 204 No content - if the operation succeed but no eperson is set for this policy
@@ -358,8 +356,6 @@ Return codes:
 **/api/authz/resourcepolicies/<:id>/group**
 
 Return the group linked by this resource policy
-
-The recipient of the policy, eperson or group, cannot be modified. If you need to do so please delete the policy and create a new one.
 
 Return codes:
 * 200 Ok if the operation succeed and a group is linked to this resource policy


### PR DESCRIPTION
Fixes https://github.com/DSpace/DSpace/issues/10609

I have confirmed that the PUT operations are supported by the REST API and UI.

I have also confirmed this is true for dspace-8_x, so it should be backported for 8.

The conflicting remarks (with PUT description) also exist in dspace-7_x version of the REST contract, so I think this should also be backported to 7.