### PR TITLE
Explain metadata registry requirement for PATCH paths

### DIFF
--- a/metadata-patch.md
+++ b/metadata-patch.md
@@ -35,6 +35,13 @@ The examples in each section below build on each other, assuming an initial meta
 }
 ```
 
+PATCH operations targeting metadata must specify a JSON `path` relative to the DSpace object, valid for the following levels:
+- All metadata: `/metadata` → `value` must be an object (if applicable)
+- All values of one metadata field: `/metadata/dc.title` → `value` must be an array (if applicable)
+- One values of one metadata field: `/metadata/dc.title/0` → `value` must be an object (if applicable)
+
+Any metadata field explicitly included in the `path` must be part the metadata registry. PATCH requests targeting unknown metadata fields will fail with HTTP 422 (unprocessable entity).
+
 Note: The metadata of items _in submission_ is modeled in the same way described here -- as a map
 of metadata keys to an ordered array of values. The primary difference is where the metadata
 is located within the JSON representation. The documentation and examples below apply to archived


### PR DESCRIPTION
Currently, metadata PATCH requests with `"op": "replace"` and an unknown metadata field in the `path` are treated as if they have `"path": "/metadata"`. This can lead to unexpected loss of metadata as detailed in https://github.com/DSpace/DSpace/issues/10817

This PR documents the changes made in https://github.com/DSpace/DSpace/pull/10961 to resolve this problem: any unknown field in the `path` will immediately lead to an HTTP 422 response.

The change affects all PATCH operations, to avoid similar problems.

